### PR TITLE
[Refactor] Add BloomingDetails peopleCount

### DIFF
--- a/core/core-api/src/main/kotlin/com/pida/presentation/v1/blooming/response/BloomingDetailsResponse.kt
+++ b/core/core-api/src/main/kotlin/com/pida/presentation/v1/blooming/response/BloomingDetailsResponse.kt
@@ -1,14 +1,55 @@
 package com.pida.presentation.v1.blooming.response
 
 import com.pida.blooming.BloomingDetails
+import com.pida.blooming.BloomingStatusDetails
 import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "개화 상태 상세 조회 응답 Json")
 data class BloomingDetailsResponse(
-    @Schema(description = "최근 방문한 개화 상태 수", example = "10")
+    @Schema(description = "최근 방문한 개화 상태 수", example = "9")
     val totalCount: Long,
-    @Schema(description = "개화 상태 상세 정보", example = "{ \"2025-04-01\": { \"BLOOMING\": 50, \"WITHERED\": 50 } }")
-    val details: Map<String, Map<String, Int>>,
+    @Schema(
+        description = "개화 상태 상세 정보",
+        example = """
+    {
+        "2025-03-27": {
+            "BLOOMED": {
+                "peopleCount": 1,
+                "percentage": 100
+            }
+        },
+        "2025-03-26": {
+            "BLOOMED": {
+                "peopleCount": 1,
+                "percentage": 100
+            }
+        },
+        "2025-03-25": {
+            "BLOOMED": {
+                "peopleCount": 1,
+                "percentage": 50
+            },
+            "WITHERED": {
+                "peopleCount": 1,
+                "percentage": 50
+            }
+        },
+        "2025-03-24": {
+            "BLOOMED": {
+                "peopleCount": 2,
+                "percentage": 100
+            }
+        },
+        "2025-03-23": {
+            "BLOOMED": {
+                "peopleCount": 3,
+                "percentage": 100
+            }
+        }
+    }
+    """,
+    )
+    val details: Map<String, Map<String, BloomingStatusDetails>>,
 ) {
     companion object {
         fun from(bloomingDetails: BloomingDetails): BloomingDetailsResponse =

--- a/core/core-domain/src/main/kotlin/com/pida/blooming/BloomingDetails.kt
+++ b/core/core-domain/src/main/kotlin/com/pida/blooming/BloomingDetails.kt
@@ -2,5 +2,5 @@ package com.pida.blooming
 
 data class BloomingDetails(
     val totalCount: Long,
-    val details: Map<String, Map<String, Int>>,
+    val details: Map<String, Map<String, BloomingStatusDetails>>,
 )

--- a/core/core-domain/src/main/kotlin/com/pida/blooming/BloomingService.kt
+++ b/core/core-domain/src/main/kotlin/com/pida/blooming/BloomingService.kt
@@ -26,7 +26,7 @@ class BloomingService(
 
         val totalCount = bloomings.size.toLong()
 
-        val details =
+        val details: Map<String, Map<String, BloomingStatusDetails>> =
             bloomings
                 .groupBy { it.createdAt.toLocalDate().toString() }
                 .entries
@@ -34,19 +34,21 @@ class BloomingService(
                 .associate { (date, bloomingsOnDate) ->
                     val dailyTotal = bloomingsOnDate.size.toDouble()
 
-                    val statusMap =
+                    val statusCounts =
                         bloomingsOnDate
                             .groupingBy { it.status.name }
                             .eachCount()
-                            .mapValues { (_, count) ->
-                                if (dailyTotal == 0.0) {
-                                    0
-                                } else {
-                                    ((count / dailyTotal) * 100).roundToInt()
-                                }
-                            }
 
-                    date to statusMap
+                    val statusDetailsMap =
+                        statusCounts.mapValues { (_, count) ->
+                            val percentage = if (dailyTotal == 0.0) 0 else ((count / dailyTotal) * 100).roundToInt()
+                            BloomingStatusDetails(
+                                peopleCount = count,
+                                percentage = percentage,
+                            )
+                        }
+
+                    date to statusDetailsMap
                 }
 
         return BloomingDetails(

--- a/core/core-domain/src/main/kotlin/com/pida/blooming/BloomingStatusDetails.kt
+++ b/core/core-domain/src/main/kotlin/com/pida/blooming/BloomingStatusDetails.kt
@@ -1,0 +1,6 @@
+package com.pida.blooming
+
+data class BloomingStatusDetails(
+    val peopleCount: Int,
+    val percentage: Int,
+)


### PR DESCRIPTION
## 🌱 관련 이슈
- close #26 

## 📌 작업 내용 및 특이 사항

- 0586dcfd20833e512667160e86389e54008cb8f9: Add BloomingStatusDetails peopleCount

## 📝 참고

#### 변경 전

```
"details": {
        "2025-03-27": {
            "BLOOMED": 100
        },
        "2025-03-26": {
            "BLOOMED": 100
        },
        "2025-03-25": {
            "BLOOMED": 60
            "WITHERED": 40
        },
        "2025-03-24": {
            "BLOOMED": 100
        },
        "2025-03-23": {
            "BLOOMED": 100
        }
    }
```

#### 변경 후

```
"details": {
        "2025-03-27": {
            "BLOOMED": {
                "peopleCount": 1,
                "percentage": 100
            }
        },
        "2025-03-26": {
            "BLOOMED": {
                "peopleCount": 1,
                "percentage": 100
            }
        },
        "2025-03-25": {
            "BLOOMED": {
                "peopleCount": 1,
                "percentage": 50
            },
            "WITHERED": {
                "peopleCount": 1,
                "percentage": 50
            }
        },
        "2025-03-24": {
            "BLOOMED": {
                "peopleCount": 2,
                "percentage": 100
            }
        },
        "2025-03-23": {
            "BLOOMED": {
                "peopleCount": 3,
                "percentage": 100
            }
        }
    }
```

## 📌 체크 리스트
<!-- 
    조건을 만족하셨다면 공백 대신 x 를 넣어주세요.
    ex:
    - [x] ~~
    - [ ] ~~
-->
- [ ] 리뷰어를 추가하셨나요 ?
- [ ] 변경사항에 대해 충분히 설명하고 있나요 ?