### PR TITLE
[Feature] Add preview image URLs to flowerspot place list response

### DIFF
--- a/pida-core/core-api/src/main/kotlin/com/pida/presentation/v1/flowerspot/response/FlowerSpotAllResponse.kt
+++ b/pida-core/core-api/src/main/kotlin/com/pida/presentation/v1/flowerspot/response/FlowerSpotAllResponse.kt
@@ -67,6 +67,12 @@ data class FlowerSpotResponseDto(
     val region: Region,
     @Schema(description = "꽃 종류", example = "BLOSSOM")
     val kind: FlowerKind,
+    @Schema(
+        description = "미리보기 이미지 URL",
+        example = "https://example.com/image1.jpg",
+        requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+    )
+    val previewUrl: String?,
     @Schema(description = "삭제 여부")
     val deletedAt: LocalDateTime?,
 ) {
@@ -84,6 +90,7 @@ data class FlowerSpotResponseDto(
                 pinPoint = flowerSpot.pinPoint,
                 region = flowerSpot.region,
                 kind = flowerSpot.kind,
+                previewUrl = flowerSpot.imageUrls.firstOrNull(),
                 deletedAt = flowerSpot.deletedAt,
             )
     }

--- a/pida-core/core-domain/src/main/kotlin/com/pida/flowerspot/FlowerSpotFacade.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/flowerspot/FlowerSpotFacade.kt
@@ -44,6 +44,12 @@ class FlowerSpotFacade(
             FlowerSpotDetails.of(
                 flowerSpot = flowerSpot,
                 bloomings = recentlyBlooming.groupBy { it.flowerSpotId }[flowerSpot.id] ?: emptyList(),
+                imageUrls =
+                    imageS3Caller.getImageUrl(
+                        prefix = ImagePrefix.FLOWERSPOT.value,
+                        prefixId = flowerSpot.id,
+                        fileName = null,
+                    ),
             )
         }
     }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #80 

## 📌 작업 내용 및 특이 사항

- 벚꽃 장소 조회 API 응답에 미리보기 이미지 url을 추가하였습니다.

## 📝 참고

- preview 이미지는 해당 장소 이미지 목록에서 첫 번째 이미지를 불러옵니다

## 📌 체크 리스트
<!-- 
    조건을 만족하셨다면 공백 대신 x 를 넣어주세요.
    ex:
    - [x] ~~
    - [ ] ~~
-->
- [ ] 리뷰어를 추가하셨나요 ?
- [ ] 변경사항에 대해 충분히 설명하고 있나요 ?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Flower spot API responses now include preview image URLs for better visual identification.
  * Preview images are automatically sourced from available images for each flower spot location.
  * Image data is consistently available in both detailed views and list-view API endpoints.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->