### PR TITLE
refactor: 행정구역 검색 포함하고 coroutineScope 활용한 병렬 요청

### DIFF
--- a/pida-clients/map-client/src/main/kotlin/com/pida/client/map/KakaoMapClient.kt
+++ b/pida-clients/map-client/src/main/kotlin/com/pida/client/map/KakaoMapClient.kt
@@ -1,7 +1,7 @@
 package com.pida.client.map
 
-import com.pida.landmark.LandmarkSearchClient
-import com.pida.landmark.NewLandmark
+import com.pida.place.LandmarkSearchClient
+import com.pida.place.NewLandmark
 import com.pida.support.extension.logger
 import com.pida.support.geo.toRegion
 import org.springframework.stereotype.Component

--- a/pida-core/core-api/src/main/kotlin/com/pida/presentation/v1/flowerspot/FlowerSpotController.kt
+++ b/pida-core/core-api/src/main/kotlin/com/pida/presentation/v1/flowerspot/FlowerSpotController.kt
@@ -6,10 +6,7 @@ import com.pida.presentation.v1.annotation.ApiV1Controller
 import com.pida.presentation.v1.flowerspot.response.FlowerSpotAllResponse
 import com.pida.presentation.v1.flowerspot.response.FlowerSpotDetailsResponse
 import com.pida.presentation.v1.flowerspot.response.FlowerSpotResponseDto
-import com.pida.presentation.v1.flowerspot.response.FlowerSpotSearchResponse
-import com.pida.presentation.v1.flowerspot.response.PlaceSearchResponse
 import com.pida.support.geo.Region
-import com.pida.user.User
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.tags.Tag
@@ -52,19 +49,5 @@ class FlowerSpotController(
     ): FlowerSpotDetailsResponse {
         val flowerSpot = flowerSpotFacade.readFlowerSpotDetails(spotId)
         return FlowerSpotDetailsResponse.of(flowerSpot)
-    }
-
-    @Operation(summary = "랜드마크 및 벚꽃길 검색", description = "검색 우선순위에 맞게 랜드마크와 벚꽃길을 검색합니다.")
-    @GetMapping("/flower-spot/search")
-    suspend fun searchFlowerSpot(
-        @RequestParam @Parameter(name = "query", description = "검색 키워드") query: String,
-        @Parameter(hidden = true, required = false) user: User?,
-    ): FlowerSpotSearchResponse {
-        val searchResult = flowerSpotFacade.search(query, user)
-
-        return FlowerSpotSearchResponse.of(
-            landmarks = searchResult.landmarks.map { PlaceSearchResponse.from(it) },
-            flowerSpots = searchResult.flowerSpots.map { PlaceSearchResponse.from(it) },
-        )
     }
 }

--- a/pida-core/core-api/src/main/kotlin/com/pida/presentation/v1/flowerspot/response/FlowerSpotSearchResponse.kt
+++ b/pida-core/core-api/src/main/kotlin/com/pida/presentation/v1/flowerspot/response/FlowerSpotSearchResponse.kt
@@ -1,7 +1,7 @@
 package com.pida.presentation.v1.flowerspot.response
 
 import com.pida.flowerspot.FlowerSpot
-import com.pida.landmark.Landmark
+import com.pida.place.Landmark
 import com.pida.support.geo.GeoJson
 import com.pida.support.geo.Region
 import io.swagger.v3.oas.annotations.media.ArraySchema

--- a/pida-core/core-api/src/main/kotlin/com/pida/presentation/v1/place/PlaceController.kt
+++ b/pida-core/core-api/src/main/kotlin/com/pida/presentation/v1/place/PlaceController.kt
@@ -44,6 +44,7 @@ class PlaceController(
         val searchResult = placeFacade.search(query, user)
 
         return PlaceSearchResultResponse.of(
+            district = searchResult.districts.map { PlaceSearchResponse.from(it) },
             landmarks = searchResult.landmarks.map { PlaceSearchResponse.from(it) },
             flowerSpots = searchResult.flowerSpots.map { PlaceSearchResponse.from(it) },
         )

--- a/pida-core/core-api/src/main/kotlin/com/pida/presentation/v1/place/PlaceController.kt
+++ b/pida-core/core-api/src/main/kotlin/com/pida/presentation/v1/place/PlaceController.kt
@@ -1,0 +1,29 @@
+package com.pida.presentation.v1.place
+
+import com.pida.place.DistrictService
+import com.pida.presentation.v1.annotation.ApiV1Controller
+import com.pida.presentation.v1.place.request.AddDistrictRequest
+import io.swagger.v3.oas.annotations.Hidden
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.ResponseStatus
+
+@Tag(name = "📍 Place API", description = "장소 관련 API")
+@ApiV1Controller
+class PlaceController(
+    private val districtService: DistrictService,
+) {
+    @Hidden
+    @Operation(summary = "행정구역 데이터 저장", description = "행정구역 데이터를 저장합니다.")
+    @PostMapping("/places")
+    @ResponseStatus(HttpStatus.CREATED)
+    fun placeAdd(
+        @RequestBody @Valid requests: List<AddDistrictRequest>,
+    ) {
+        districtService.addAll(requests.map { it.toDistrict() })
+    }
+}

--- a/pida-core/core-api/src/main/kotlin/com/pida/presentation/v1/place/PlaceController.kt
+++ b/pida-core/core-api/src/main/kotlin/com/pida/presentation/v1/place/PlaceController.kt
@@ -1,21 +1,29 @@
 package com.pida.presentation.v1.place
 
 import com.pida.place.DistrictService
+import com.pida.place.PlaceFacade
 import com.pida.presentation.v1.annotation.ApiV1Controller
 import com.pida.presentation.v1.place.request.AddDistrictRequest
+import com.pida.presentation.v1.place.response.PlaceSearchResponse
+import com.pida.presentation.v1.place.response.PlaceSearchResultResponse
+import com.pida.user.User
 import io.swagger.v3.oas.annotations.Hidden
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseStatus
 
 @Tag(name = "📍 Place API", description = "장소 관련 API")
 @ApiV1Controller
 class PlaceController(
     private val districtService: DistrictService,
+    private val placeFacade: PlaceFacade,
 ) {
     @Hidden
     @Operation(summary = "행정구역 데이터 저장", description = "행정구역 데이터를 저장합니다.")
@@ -25,5 +33,19 @@ class PlaceController(
         @RequestBody @Valid requests: List<AddDistrictRequest>,
     ) {
         districtService.addAll(requests.map { it.toDistrict() })
+    }
+
+    @Operation(summary = "랜드마크 및 벚꽃길 검색", description = "검색 우선순위에 맞게 랜드마크와 벚꽃길을 검색합니다.")
+    @GetMapping("/places/search")
+    suspend fun searchPlace(
+        @RequestParam @Parameter(name = "query", description = "검색 키워드") query: String,
+        @Parameter(hidden = true, required = false) user: User?,
+    ): PlaceSearchResultResponse {
+        val searchResult = placeFacade.search(query, user)
+
+        return PlaceSearchResultResponse.of(
+            landmarks = searchResult.landmarks.map { PlaceSearchResponse.from(it) },
+            flowerSpots = searchResult.flowerSpots.map { PlaceSearchResponse.from(it) },
+        )
     }
 }

--- a/pida-core/core-api/src/main/kotlin/com/pida/presentation/v1/place/request/AddDistrictRequest.kt
+++ b/pida-core/core-api/src/main/kotlin/com/pida/presentation/v1/place/request/AddDistrictRequest.kt
@@ -1,0 +1,41 @@
+package com.pida.presentation.v1.place.request
+
+import com.pida.place.District
+import com.pida.support.geo.GeoJson
+import com.pida.support.geo.toRegion
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+
+@Schema(description = "행정구역 데이터 저장 요청")
+data class AddDistrictRequest(
+    @field:NotBlank
+    @field:Schema(description = "시도", example = "경기도", requiredMode = Schema.RequiredMode.REQUIRED)
+    val sido: String,
+    @field:NotBlank
+    @field:Schema(description = "시군구", example = "용인시", requiredMode = Schema.RequiredMode.REQUIRED)
+    val sigungu: String,
+    @field:Schema(description = "읍면동구", example = "처인구", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    val eupmyeondonggu: String?,
+    @field:Schema(description = "읍면리동", example = "남사면", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    val eupmyeonridong: String?,
+    @field:Schema(description = "리", example = "완장리", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    val ri: String?,
+    @field:NotNull
+    @field:Schema(description = "경도", example = "127.1746", requiredMode = Schema.RequiredMode.REQUIRED)
+    val x: Double,
+    @field:NotNull
+    @field:Schema(description = "위도", example = "37.1678", requiredMode = Schema.RequiredMode.REQUIRED)
+    val y: Double,
+) {
+    fun toDistrict(): District =
+        District(
+            id = 0L,
+            sido = sido.toRegion(),
+            sigungu = sigungu,
+            eupmyeondonggu = eupmyeondonggu,
+            eupmyeonridong = eupmyeonridong,
+            ri = ri,
+            pinPoint = GeoJson.Point(listOf(x, y)),
+        )
+}

--- a/pida-core/core-api/src/main/kotlin/com/pida/presentation/v1/place/request/AddDistrictRequest.kt
+++ b/pida-core/core-api/src/main/kotlin/com/pida/presentation/v1/place/request/AddDistrictRequest.kt
@@ -12,9 +12,8 @@ data class AddDistrictRequest(
     @field:NotBlank
     @field:Schema(description = "시도", example = "경기도", requiredMode = Schema.RequiredMode.REQUIRED)
     val sido: String,
-    @field:NotBlank
-    @field:Schema(description = "시군구", example = "용인시", requiredMode = Schema.RequiredMode.REQUIRED)
-    val sigungu: String,
+    @field:Schema(description = "시군구", example = "용인시", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    val sigungu: String?,
     @field:Schema(description = "읍면동구", example = "처인구", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     val eupmyeondonggu: String?,
     @field:Schema(description = "읍면리동", example = "남사면", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
@@ -31,11 +30,12 @@ data class AddDistrictRequest(
     fun toDistrict(): District =
         District(
             id = 0L,
-            sido = sido.toRegion(),
+            sido = sido,
             sigungu = sigungu,
             eupmyeondonggu = eupmyeondonggu,
             eupmyeonridong = eupmyeonridong,
             ri = ri,
             pinPoint = GeoJson.Point(listOf(x, y)),
+            region = sido.toRegion(),
         )
 }

--- a/pida-core/core-api/src/main/kotlin/com/pida/presentation/v1/place/response/PlaceSearchResponse.kt
+++ b/pida-core/core-api/src/main/kotlin/com/pida/presentation/v1/place/response/PlaceSearchResponse.kt
@@ -74,9 +74,13 @@ data class PlaceSearchResponse(
         fun from(district: District) =
             PlaceSearchResponse(
                 name =
+                    listOfNotNull(district.sido, district.sigungu, district.eupmyeondonggu, district.eupmyeonridong, district.ri)
+                        .last(),
+                address =
                     listOfNotNull(district.sigungu, district.eupmyeondonggu, district.eupmyeonridong, district.ri)
-                        .joinToString(" "),
-                address = null,
+                        .takeIf { it.isNotEmpty() }
+                        ?.let { listOf(district.sido) + it }
+                        ?.joinToString(" "),
                 pinPoint = district.pinPoint,
                 region = district.region,
             )

--- a/pida-core/core-api/src/main/kotlin/com/pida/presentation/v1/place/response/PlaceSearchResponse.kt
+++ b/pida-core/core-api/src/main/kotlin/com/pida/presentation/v1/place/response/PlaceSearchResponse.kt
@@ -1,6 +1,7 @@
 package com.pida.presentation.v1.place.response
 
 import com.pida.flowerspot.FlowerSpot
+import com.pida.place.District
 import com.pida.place.Landmark
 import com.pida.support.geo.GeoJson
 import com.pida.support.geo.Region
@@ -9,6 +10,11 @@ import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "랜드마크 및 벚꽃길 검색 응답")
 data class PlaceSearchResultResponse(
+    @field:ArraySchema(
+        schema = Schema(implementation = PlaceSearchResponse::class),
+        arraySchema = Schema(description = "행정구역 목록"),
+    )
+    val district: List<PlaceSearchResponse>,
     @field:ArraySchema(
         schema = Schema(implementation = PlaceSearchResponse::class),
         arraySchema = Schema(description = "랜드마크 목록"),
@@ -22,9 +28,10 @@ data class PlaceSearchResultResponse(
 ) {
     companion object {
         fun of(
+            district: List<PlaceSearchResponse>,
             landmarks: List<PlaceSearchResponse>,
             flowerSpots: List<PlaceSearchResponse>,
-        ) = PlaceSearchResultResponse(landmarks, flowerSpots)
+        ) = PlaceSearchResultResponse(district, landmarks, flowerSpots)
     }
 }
 
@@ -62,6 +69,16 @@ data class PlaceSearchResponse(
                 address = flowerSpot.address,
                 pinPoint = flowerSpot.pinPoint,
                 region = flowerSpot.region,
+            )
+
+        fun from(district: District) =
+            PlaceSearchResponse(
+                name =
+                    listOfNotNull(district.sigungu, district.eupmyeondonggu, district.eupmyeonridong, district.ri)
+                        .joinToString(" "),
+                address = null,
+                pinPoint = district.pinPoint,
+                region = district.sido,
             )
     }
 }

--- a/pida-core/core-api/src/main/kotlin/com/pida/presentation/v1/place/response/PlaceSearchResponse.kt
+++ b/pida-core/core-api/src/main/kotlin/com/pida/presentation/v1/place/response/PlaceSearchResponse.kt
@@ -1,4 +1,4 @@
-package com.pida.presentation.v1.flowerspot.response
+package com.pida.presentation.v1.place.response
 
 import com.pida.flowerspot.FlowerSpot
 import com.pida.place.Landmark
@@ -8,7 +8,7 @@ import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "랜드마크 및 벚꽃길 검색 응답")
-data class FlowerSpotSearchResponse(
+data class PlaceSearchResultResponse(
     @field:ArraySchema(
         schema = Schema(implementation = PlaceSearchResponse::class),
         arraySchema = Schema(description = "랜드마크 목록"),
@@ -24,7 +24,7 @@ data class FlowerSpotSearchResponse(
         fun of(
             landmarks: List<PlaceSearchResponse>,
             flowerSpots: List<PlaceSearchResponse>,
-        ) = FlowerSpotSearchResponse(landmarks, flowerSpots)
+        ) = PlaceSearchResultResponse(landmarks, flowerSpots)
     }
 }
 

--- a/pida-core/core-api/src/main/kotlin/com/pida/presentation/v1/place/response/PlaceSearchResponse.kt
+++ b/pida-core/core-api/src/main/kotlin/com/pida/presentation/v1/place/response/PlaceSearchResponse.kt
@@ -78,7 +78,7 @@ data class PlaceSearchResponse(
                         .joinToString(" "),
                 address = null,
                 pinPoint = district.pinPoint,
-                region = district.sido,
+                region = district.region,
             )
     }
 }

--- a/pida-core/core-domain/src/main/kotlin/com/pida/flowerspot/FlowerSpotFacade.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/flowerspot/FlowerSpotFacade.kt
@@ -1,33 +1,19 @@
 package com.pida.flowerspot
 
 import com.pida.blooming.BloomingService
-import com.pida.place.Landmark
-import com.pida.place.LandmarkFetchEvent
-import com.pida.place.LandmarkSearchClient
-import com.pida.place.LandmarkService
-import com.pida.place.NewLandmark
 import com.pida.support.aws.ImagePrefix
 import com.pida.support.aws.ImageS3Caller
 import com.pida.support.geo.Region
-import com.pida.user.User
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
-import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
 
 @Service
 class FlowerSpotFacade(
     private val flowerSpotService: FlowerSpotService,
     private val bloomingService: BloomingService,
-    private val landmarkService: LandmarkService,
-    private val landmarkSearchClient: LandmarkSearchClient,
     private val imageS3Caller: ImageS3Caller,
-    private val eventPublisher: ApplicationEventPublisher,
 ) {
-    companion object {
-        private const val MIN_SEARCH_RESULT_COUNT = 2
-    }
-
     suspend fun readFlowerSpotDetails(spotId: Long): FlowerSpotDetails =
         coroutineScope {
             val flowerSpotDeferred = async { flowerSpotService.readOneFlowerSpot(spotId) }
@@ -68,51 +54,4 @@ class FlowerSpotFacade(
             )
         }
     }
-
-    suspend fun search(
-        query: String,
-        user: User?,
-    ): FlowerSpotSearchResult {
-        publishSearchEvent(query, user)
-
-        val flowerSpots = flowerSpotService.searchFlowerSpots(query)
-        val cachedLandmarks = landmarkService.searchLandmarks(query)
-
-        val landmarks =
-            if (hasEnough(cachedLandmarks)) {
-                // 캐시된 랜드마크가 충분한 경우 즉시 응답 후에 비동기적으로 보정
-                publishLandmarkFetchEvent(query, null)
-                cachedLandmarks
-            } else {
-                // 캐시된 랜드마크가 충분하지 않은 경우, 외부 API 호출 대기
-                val fetched = landmarkSearchClient.searchByKeyword(query)
-                publishLandmarkFetchEvent(query, fetched)
-                fetched.map { it.toLandmark() }
-            }
-
-        return FlowerSpotSearchResult(landmarks, flowerSpots)
-    }
-
-    private fun publishLandmarkFetchEvent(
-        query: String,
-        fetchedLandmark: List<NewLandmark>?,
-    ) {
-        eventPublisher.publishEvent(
-            LandmarkFetchEvent.from(query, fetchedLandmark),
-        )
-    }
-
-    private fun publishSearchEvent(
-        query: String,
-        user: User?,
-    ) {
-        eventPublisher.publishEvent(
-            FlowerSpotSearchEvent(
-                query = query,
-                userId = user?.id,
-            ),
-        )
-    }
-
-    private fun hasEnough(landmarks: List<Landmark>) = landmarks.size >= MIN_SEARCH_RESULT_COUNT
 }

--- a/pida-core/core-domain/src/main/kotlin/com/pida/flowerspot/FlowerSpotFacade.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/flowerspot/FlowerSpotFacade.kt
@@ -1,11 +1,11 @@
 package com.pida.flowerspot
 
 import com.pida.blooming.BloomingService
-import com.pida.landmark.Landmark
-import com.pida.landmark.LandmarkFetchEvent
-import com.pida.landmark.LandmarkSearchClient
-import com.pida.landmark.LandmarkService
-import com.pida.landmark.NewLandmark
+import com.pida.place.Landmark
+import com.pida.place.LandmarkFetchEvent
+import com.pida.place.LandmarkSearchClient
+import com.pida.place.LandmarkService
+import com.pida.place.NewLandmark
 import com.pida.support.aws.ImagePrefix
 import com.pida.support.aws.ImageS3Caller
 import com.pida.support.geo.Region

--- a/pida-core/core-domain/src/main/kotlin/com/pida/flowerspot/FlowerSpotFinder.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/flowerspot/FlowerSpotFinder.kt
@@ -11,7 +11,8 @@ class FlowerSpotFinder(
     private val cacheAdvice: CacheAdvice,
 ) {
     companion object {
-        val ALL_SPOT = "spot:all"
+        const val ALL_SPOT = "spot:all"
+        const val SEARCH_KEY = "spot:search"
     }
 
     suspend fun readAll(): List<FlowerSpot> =
@@ -49,5 +50,12 @@ class FlowerSpotFinder(
         location: FlowerSpotLocation,
     ): List<FlowerSpot> = flowerSpotRepository.findAllByLocationAndRegion(region, location)
 
-    fun searchByStreetName(streetName: String): List<FlowerSpot> = flowerSpotRepository.findByStreetNameContaining(streetName)
+    suspend fun searchByStreetName(streetName: String): List<FlowerSpot> =
+        cacheAdvice.invoke(
+            ttl = 180L,
+            key = "$SEARCH_KEY:$streetName",
+            typeReference = object : TypeReference<List<FlowerSpot>>() {},
+        ) {
+            flowerSpotRepository.findByStreetNameContaining(streetName)
+        }
 }

--- a/pida-core/core-domain/src/main/kotlin/com/pida/flowerspot/FlowerSpotSearchResult.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/flowerspot/FlowerSpotSearchResult.kt
@@ -1,8 +1,0 @@
-package com.pida.flowerspot
-
-import com.pida.place.Landmark
-
-data class FlowerSpotSearchResult(
-    val landmarks: List<Landmark>,
-    val flowerSpots: List<FlowerSpot>,
-)

--- a/pida-core/core-domain/src/main/kotlin/com/pida/flowerspot/FlowerSpotSearchResult.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/flowerspot/FlowerSpotSearchResult.kt
@@ -1,6 +1,6 @@
 package com.pida.flowerspot
 
-import com.pida.landmark.Landmark
+import com.pida.place.Landmark
 
 data class FlowerSpotSearchResult(
     val landmarks: List<Landmark>,

--- a/pida-core/core-domain/src/main/kotlin/com/pida/flowerspot/FlowerSpotService.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/flowerspot/FlowerSpotService.kt
@@ -23,7 +23,7 @@ class FlowerSpotService(
 
     suspend fun readOneFlowerSpot(spotId: Long): FlowerSpot = flowerSpotFinder.readBy(spotId)
 
-    fun searchFlowerSpots(query: String): List<FlowerSpot> {
+    suspend fun searchFlowerSpots(query: String): List<FlowerSpot> {
         val trimmed = query.trim()
         if (trimmed.isEmpty()) return emptyList()
 

--- a/pida-core/core-domain/src/main/kotlin/com/pida/landmark/District.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/landmark/District.kt
@@ -1,0 +1,13 @@
+package com.pida.landmark
+
+import com.pida.support.geo.GeoJson
+import com.pida.support.geo.Region
+
+data class District(
+    val id: Long,
+    val sido: Region,
+    val sigungu: String,
+    val eupmyeondong: String?,
+    val ri: String?,
+    val pinPoint: GeoJson,
+)

--- a/pida-core/core-domain/src/main/kotlin/com/pida/place/District.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/place/District.kt
@@ -7,7 +7,8 @@ data class District(
     val id: Long,
     val sido: Region,
     val sigungu: String,
-    val eupmyeondong: String?,
+    val eupmyeondonggu: String?,
+    val eupmyeonridong: String?,
     val ri: String?,
     val pinPoint: GeoJson,
 )

--- a/pida-core/core-domain/src/main/kotlin/com/pida/place/District.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/place/District.kt
@@ -5,10 +5,11 @@ import com.pida.support.geo.Region
 
 data class District(
     val id: Long,
-    val sido: Region,
-    val sigungu: String,
+    val sido: String,
+    val sigungu: String?,
     val eupmyeondonggu: String?,
     val eupmyeonridong: String?,
     val ri: String?,
     val pinPoint: GeoJson,
+    val region: Region,
 )

--- a/pida-core/core-domain/src/main/kotlin/com/pida/place/District.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/place/District.kt
@@ -1,4 +1,4 @@
-package com.pida.landmark
+package com.pida.place
 
 import com.pida.support.geo.GeoJson
 import com.pida.support.geo.Region

--- a/pida-core/core-domain/src/main/kotlin/com/pida/place/DistrictAppender.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/place/DistrictAppender.kt
@@ -1,0 +1,16 @@
+package com.pida.place
+
+import com.pida.support.tx.TransactionTemplates
+import org.springframework.stereotype.Component
+
+@Component
+class DistrictAppender(
+    private val districtRepository: DistrictRepository,
+    private val tx: TransactionTemplates,
+) {
+    fun addAll(districts: List<District>) {
+        tx.writer.execute {
+            districtRepository.saveAll(districts)
+        }
+    }
+}

--- a/pida-core/core-domain/src/main/kotlin/com/pida/place/DistrictFinder.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/place/DistrictFinder.kt
@@ -1,0 +1,25 @@
+package com.pida.place
+
+import com.fasterxml.jackson.core.type.TypeReference
+import com.pida.support.cache.CacheAdvice
+import org.springframework.stereotype.Component
+
+@Component
+class DistrictFinder(
+    private val districtRepository: DistrictRepository,
+    private val cacheAdvice: CacheAdvice,
+) {
+    companion object {
+        private const val DISTRICT_PREFIX = "district"
+        const val SEARCH_KEY = "$DISTRICT_PREFIX:search"
+    }
+
+    suspend fun searchByKeyword(keyword: String): List<District> =
+        cacheAdvice.invoke(
+            ttl = 180L,
+            key = "$SEARCH_KEY:$keyword",
+            typeReference = object : TypeReference<List<District>>() {},
+        ) {
+            districtRepository.searchByKeyword(keyword)
+        }
+}

--- a/pida-core/core-domain/src/main/kotlin/com/pida/place/DistrictRepository.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/place/DistrictRepository.kt
@@ -2,4 +2,6 @@ package com.pida.place
 
 interface DistrictRepository {
     fun saveAll(districts: List<District>)
+
+    fun searchByKeyword(keyword: String): List<District>
 }

--- a/pida-core/core-domain/src/main/kotlin/com/pida/place/DistrictRepository.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/place/DistrictRepository.kt
@@ -1,0 +1,5 @@
+package com.pida.place
+
+interface DistrictRepository {
+    fun saveAll(districts: List<District>)
+}

--- a/pida-core/core-domain/src/main/kotlin/com/pida/place/DistrictService.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/place/DistrictService.kt
@@ -12,6 +12,7 @@ class DistrictService(
     }
 
     suspend fun searchDistricts(query: String): List<District> {
+        if (query.isBlank()) return emptyList() // 빈 쿼리인 경우 빈 리스트 반환
         val keywords = query.trim().split("\\s+".toRegex()) // 공백 제거 후 단어별로 분리
         val results = districtFinder.searchByKeyword(keywords.first()) // 첫 번째 키워드로 검색
 

--- a/pida-core/core-domain/src/main/kotlin/com/pida/place/DistrictService.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/place/DistrictService.kt
@@ -1,0 +1,12 @@
+package com.pida.place
+
+import org.springframework.stereotype.Service
+
+@Service
+class DistrictService(
+    private val districtAppender: DistrictAppender,
+) {
+    fun addAll(districts: List<District>) {
+        districtAppender.addAll(districts)
+    }
+}

--- a/pida-core/core-domain/src/main/kotlin/com/pida/place/DistrictService.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/place/DistrictService.kt
@@ -20,7 +20,7 @@ class DistrictService(
         return results.filter { district ->
             // 나머지 키워드들로 필터링
             val fullText =
-                listOfNotNull(district.sigungu, district.eupmyeondonggu, district.eupmyeonridong, district.ri)
+                listOfNotNull(district.sido, district.sigungu, district.eupmyeondonggu, district.eupmyeonridong, district.ri)
                     .joinToString(" ")
             keywords.drop(1).all { keyword -> fullText.contains(keyword) }
         }

--- a/pida-core/core-domain/src/main/kotlin/com/pida/place/DistrictService.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/place/DistrictService.kt
@@ -5,8 +5,24 @@ import org.springframework.stereotype.Service
 @Service
 class DistrictService(
     private val districtAppender: DistrictAppender,
+    private val districtFinder: DistrictFinder,
 ) {
     fun addAll(districts: List<District>) {
         districtAppender.addAll(districts)
+    }
+
+    suspend fun searchDistricts(query: String): List<District> {
+        val keywords = query.trim().split("\\s+".toRegex()) // 공백 제거 후 단어별로 분리
+        val results = districtFinder.searchByKeyword(keywords.first()) // 첫 번째 키워드로 검색
+
+        if (keywords.size == 1) return results
+
+        return results.filter { district ->
+            // 나머지 키워드들로 필터링
+            val fullText =
+                listOfNotNull(district.sigungu, district.eupmyeondonggu, district.eupmyeonridong, district.ri)
+                    .joinToString(" ")
+            keywords.drop(1).all { keyword -> fullText.contains(keyword) }
+        }
     }
 }

--- a/pida-core/core-domain/src/main/kotlin/com/pida/place/Landmark.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/place/Landmark.kt
@@ -1,4 +1,4 @@
-package com.pida.landmark
+package com.pida.place
 
 import com.pida.support.geo.GeoJson
 import com.pida.support.geo.Region

--- a/pida-core/core-domain/src/main/kotlin/com/pida/place/LandmarkAppender.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/place/LandmarkAppender.kt
@@ -1,4 +1,4 @@
-package com.pida.landmark
+package com.pida.place
 
 import com.pida.support.tx.TransactionTemplates
 import org.springframework.stereotype.Component

--- a/pida-core/core-domain/src/main/kotlin/com/pida/place/LandmarkFetchEvent.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/place/LandmarkFetchEvent.kt
@@ -1,4 +1,4 @@
-package com.pida.landmark
+package com.pida.place
 
 sealed interface LandmarkFetchEvent {
     val query: String

--- a/pida-core/core-domain/src/main/kotlin/com/pida/place/LandmarkFinder.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/place/LandmarkFinder.kt
@@ -1,4 +1,4 @@
-package com.pida.landmark
+package com.pida.place
 
 import com.fasterxml.jackson.core.type.TypeReference
 import com.pida.support.cache.CacheAdvice

--- a/pida-core/core-domain/src/main/kotlin/com/pida/place/LandmarkRepository.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/place/LandmarkRepository.kt
@@ -1,4 +1,4 @@
-package com.pida.landmark
+package com.pida.place
 
 interface LandmarkRepository {
     fun findAll(): List<Landmark>

--- a/pida-core/core-domain/src/main/kotlin/com/pida/place/LandmarkSearchClient.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/place/LandmarkSearchClient.kt
@@ -1,4 +1,4 @@
-package com.pida.landmark
+package com.pida.place
 
 interface LandmarkSearchClient {
     fun searchByKeyword(query: String): List<NewLandmark>

--- a/pida-core/core-domain/src/main/kotlin/com/pida/place/LandmarkService.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/place/LandmarkService.kt
@@ -1,4 +1,4 @@
-package com.pida.landmark
+package com.pida.place
 
 import com.pida.support.extension.logger
 import org.springframework.context.event.EventListener

--- a/pida-core/core-domain/src/main/kotlin/com/pida/place/NewLandmark.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/place/NewLandmark.kt
@@ -1,4 +1,4 @@
-package com.pida.landmark
+package com.pida.place
 
 import com.pida.support.geo.GeoJson
 import com.pida.support.geo.Region

--- a/pida-core/core-domain/src/main/kotlin/com/pida/place/PlaceFacade.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/place/PlaceFacade.kt
@@ -3,6 +3,8 @@ package com.pida.place
 import com.pida.flowerspot.FlowerSpotSearchEvent
 import com.pida.flowerspot.FlowerSpotService
 import com.pida.user.User
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
 
@@ -23,27 +25,33 @@ class PlaceFacade(
     suspend fun search(
         query: String,
         user: User?,
-    ): PlaceSearchResult {
-        publishSearchEvent(query, user)
+    ): PlaceSearchResult =
+        coroutineScope {
+            publishSearchEvent(query, user)
 
-        val districts = districtService.searchDistricts(query).take(MAX_DISTRICT_SEARCH_COUNT)
-        val flowerSpots = flowerSpotService.searchFlowerSpots(query)
-        val cachedLandmarks = landmarkService.searchLandmarks(query)
+            val districtsDeferred = async { districtService.searchDistricts(query) }
+            val landmarksDeferred = async { landmarkService.searchLandmarks(query) }
+            val flowerSpotsDeferred = async { flowerSpotService.searchFlowerSpots(query) }
 
-        val landmarks =
-            if (hasEnough(cachedLandmarks)) {
-                // 캐시된 랜드마크가 충분한 경우 즉시 응답 후에 비동기적으로 보정
-                publishLandmarkFetchEvent(query, null)
-                cachedLandmarks.take(MAX_LANDMARK_SEARCH_COUNT)
-            } else {
-                // 캐시된 랜드마크가 충분하지 않은 경우, 외부 API 호출 대기
-                val fetched = landmarkSearchClient.searchByKeyword(query)
-                publishLandmarkFetchEvent(query, fetched)
-                fetched.map { it.toLandmark() }.take(MAX_LANDMARK_SEARCH_COUNT)
-            }
+            val storedLandmarks = landmarksDeferred.await()
+            val landmarks =
+                if (hasEnough(storedLandmarks)) {
+                    // 저장된 랜드마크가 충분한 경우 즉시 응답 후에 비동기적으로 보정
+                    publishLandmarkFetchEvent(query, null)
+                    storedLandmarks
+                } else {
+                    // 저장된 랜드마크가 충분하지 않은 경우, 외부 API 호출 대기
+                    val fetched = landmarkSearchClient.searchByKeyword(query)
+                    publishLandmarkFetchEvent(query, fetched)
+                    fetched.map { it.toLandmark() }
+                }
 
-        return PlaceSearchResult(districts, landmarks, flowerSpots)
-    }
+            PlaceSearchResult(
+                districts = districtsDeferred.await().take(MAX_DISTRICT_SEARCH_COUNT),
+                landmarks = landmarks.take(MAX_LANDMARK_SEARCH_COUNT),
+                flowerSpots = flowerSpotsDeferred.await(),
+            )
+        }
 
     private fun publishLandmarkFetchEvent(
         query: String,

--- a/pida-core/core-domain/src/main/kotlin/com/pida/place/PlaceFacade.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/place/PlaceFacade.kt
@@ -2,6 +2,7 @@ package com.pida.place
 
 import com.pida.flowerspot.FlowerSpotSearchEvent
 import com.pida.flowerspot.FlowerSpotService
+import com.pida.support.geo.Region
 import com.pida.user.User
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
@@ -20,6 +21,7 @@ class PlaceFacade(
         private const val MAX_DISTRICT_SEARCH_COUNT = 2
         private const val MIN_LANDMARK_SEARCH_COUNT = 2
         private const val MAX_LANDMARK_SEARCH_COUNT = 5
+        private val SEARCH_REGIONS = setOf(Region.SEOUL, Region.GYEONGGI)
     }
 
     suspend fun search(
@@ -43,12 +45,12 @@ class PlaceFacade(
                     // 저장된 랜드마크가 충분하지 않은 경우, 외부 API 호출 대기
                     val fetched = landmarkSearchClient.searchByKeyword(query)
                     publishLandmarkFetchEvent(query, fetched)
-                    fetched.map { it.toLandmark() }
+                    fetched.map { it.toLandmark() }.filter { it.region in SEARCH_REGIONS }
                 }
 
             PlaceSearchResult(
                 districts = districtsDeferred.await().take(MAX_DISTRICT_SEARCH_COUNT),
-                landmarks = landmarks.take(MAX_LANDMARK_SEARCH_COUNT),
+                landmarks = landmarks.filter { it.region in SEARCH_REGIONS }.take(MAX_LANDMARK_SEARCH_COUNT),
                 flowerSpots = flowerSpotsDeferred.await(),
             )
         }

--- a/pida-core/core-domain/src/main/kotlin/com/pida/place/PlaceFacade.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/place/PlaceFacade.kt
@@ -1,7 +1,6 @@
 package com.pida.place
 
 import com.pida.flowerspot.FlowerSpotSearchEvent
-import com.pida.flowerspot.FlowerSpotSearchResult
 import com.pida.flowerspot.FlowerSpotService
 import com.pida.user.User
 import org.springframework.context.ApplicationEventPublisher
@@ -11,19 +10,23 @@ import org.springframework.stereotype.Service
 class PlaceFacade(
     private val flowerSpotService: FlowerSpotService,
     private val landmarkService: LandmarkService,
+    private val districtService: DistrictService,
     private val landmarkSearchClient: LandmarkSearchClient,
     private val eventPublisher: ApplicationEventPublisher,
 ) {
     companion object {
-        private const val MIN_SEARCH_RESULT_COUNT = 2
+        private const val MAX_DISTRICT_SEARCH_COUNT = 2
+        private const val MIN_LANDMARK_SEARCH_COUNT = 2
+        private const val MAX_LANDMARK_SEARCH_COUNT = 5
     }
 
     suspend fun search(
         query: String,
         user: User?,
-    ): FlowerSpotSearchResult {
+    ): PlaceSearchResult {
         publishSearchEvent(query, user)
 
+        val districts = districtService.searchDistricts(query).take(MAX_DISTRICT_SEARCH_COUNT)
         val flowerSpots = flowerSpotService.searchFlowerSpots(query)
         val cachedLandmarks = landmarkService.searchLandmarks(query)
 
@@ -31,15 +34,15 @@ class PlaceFacade(
             if (hasEnough(cachedLandmarks)) {
                 // 캐시된 랜드마크가 충분한 경우 즉시 응답 후에 비동기적으로 보정
                 publishLandmarkFetchEvent(query, null)
-                cachedLandmarks
+                cachedLandmarks.take(MAX_LANDMARK_SEARCH_COUNT)
             } else {
                 // 캐시된 랜드마크가 충분하지 않은 경우, 외부 API 호출 대기
                 val fetched = landmarkSearchClient.searchByKeyword(query)
                 publishLandmarkFetchEvent(query, fetched)
-                fetched.map { it.toLandmark() }
+                fetched.map { it.toLandmark() }.take(MAX_LANDMARK_SEARCH_COUNT)
             }
 
-        return FlowerSpotSearchResult(landmarks, flowerSpots)
+        return PlaceSearchResult(districts, landmarks, flowerSpots)
     }
 
     private fun publishLandmarkFetchEvent(
@@ -63,5 +66,5 @@ class PlaceFacade(
         )
     }
 
-    private fun hasEnough(landmarks: List<Landmark>) = landmarks.size >= MIN_SEARCH_RESULT_COUNT
+    private fun hasEnough(landmarks: List<Landmark>) = landmarks.size >= MIN_LANDMARK_SEARCH_COUNT
 }

--- a/pida-core/core-domain/src/main/kotlin/com/pida/place/PlaceFacade.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/place/PlaceFacade.kt
@@ -1,0 +1,67 @@
+package com.pida.place
+
+import com.pida.flowerspot.FlowerSpotSearchEvent
+import com.pida.flowerspot.FlowerSpotSearchResult
+import com.pida.flowerspot.FlowerSpotService
+import com.pida.user.User
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Service
+
+@Service
+class PlaceFacade(
+    private val flowerSpotService: FlowerSpotService,
+    private val landmarkService: LandmarkService,
+    private val landmarkSearchClient: LandmarkSearchClient,
+    private val eventPublisher: ApplicationEventPublisher,
+) {
+    companion object {
+        private const val MIN_SEARCH_RESULT_COUNT = 2
+    }
+
+    suspend fun search(
+        query: String,
+        user: User?,
+    ): FlowerSpotSearchResult {
+        publishSearchEvent(query, user)
+
+        val flowerSpots = flowerSpotService.searchFlowerSpots(query)
+        val cachedLandmarks = landmarkService.searchLandmarks(query)
+
+        val landmarks =
+            if (hasEnough(cachedLandmarks)) {
+                // 캐시된 랜드마크가 충분한 경우 즉시 응답 후에 비동기적으로 보정
+                publishLandmarkFetchEvent(query, null)
+                cachedLandmarks
+            } else {
+                // 캐시된 랜드마크가 충분하지 않은 경우, 외부 API 호출 대기
+                val fetched = landmarkSearchClient.searchByKeyword(query)
+                publishLandmarkFetchEvent(query, fetched)
+                fetched.map { it.toLandmark() }
+            }
+
+        return FlowerSpotSearchResult(landmarks, flowerSpots)
+    }
+
+    private fun publishLandmarkFetchEvent(
+        query: String,
+        fetchedLandmark: List<NewLandmark>?,
+    ) {
+        eventPublisher.publishEvent(
+            LandmarkFetchEvent.from(query, fetchedLandmark),
+        )
+    }
+
+    private fun publishSearchEvent(
+        query: String,
+        user: User?,
+    ) {
+        eventPublisher.publishEvent(
+            FlowerSpotSearchEvent(
+                query = query,
+                userId = user?.id,
+            ),
+        )
+    }
+
+    private fun hasEnough(landmarks: List<Landmark>) = landmarks.size >= MIN_SEARCH_RESULT_COUNT
+}

--- a/pida-core/core-domain/src/main/kotlin/com/pida/place/PlaceSearchResult.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/place/PlaceSearchResult.kt
@@ -1,0 +1,9 @@
+package com.pida.place
+
+import com.pida.flowerspot.FlowerSpot
+
+data class PlaceSearchResult(
+    val districts: List<District>,
+    val landmarks: List<Landmark>,
+    val flowerSpots: List<FlowerSpot>,
+)

--- a/pida-core/core-domain/src/main/kotlin/com/pida/support/geo/Region.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/support/geo/Region.kt
@@ -22,8 +22,8 @@ enum class Region {
 
 fun String.toRegion(): Region =
     when {
-        startsWith("서울") -> Region.SEOUL
-        startsWith("경기") -> Region.GYEONGGI
+        startsWith("서울") || startsWith("서울특별시") -> Region.SEOUL
+        startsWith("경기") || startsWith("경기도") -> Region.GYEONGGI
         startsWith("부산") -> Region.BUSAN
         startsWith("대구") -> Region.DAEGU
         startsWith("인천") -> Region.INCHEON

--- a/pida-storage/db-core/src/main/kotlin/com/pida/storage/db/core/district/DistrictCoreRepository.kt
+++ b/pida-storage/db-core/src/main/kotlin/com/pida/storage/db/core/district/DistrictCoreRepository.kt
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Repository
 @Repository
 class DistrictCoreRepository(
     private val districtJpaRepository: DistrictJpaRepository,
+    private val districtCustomRepository: DistrictCustomRepository,
 ) : DistrictRepository {
     companion object {
         private val GEOMETRY_FACTORY = GeometryFactory(PrecisionModel(), 4326)
@@ -31,4 +32,9 @@ class DistrictCoreRepository(
             }
         districtJpaRepository.saveAll(entities)
     }
+
+    override fun searchByKeyword(keyword: String): List<District> =
+        districtCustomRepository
+            .searchByKeyword(keyword)
+            .map { it.toDistrict() }
 }

--- a/pida-storage/db-core/src/main/kotlin/com/pida/storage/db/core/district/DistrictCoreRepository.kt
+++ b/pida-storage/db-core/src/main/kotlin/com/pida/storage/db/core/district/DistrictCoreRepository.kt
@@ -28,6 +28,7 @@ class DistrictCoreRepository(
                     eupmyeonridong = it.eupmyeonridong,
                     ri = it.ri,
                     pinPoint = GEOMETRY_FACTORY.createPoint(Coordinate(point.coordinates[0], point.coordinates[1])),
+                    region = it.region,
                 )
             }
         districtJpaRepository.saveAll(entities)

--- a/pida-storage/db-core/src/main/kotlin/com/pida/storage/db/core/district/DistrictCoreRepository.kt
+++ b/pida-storage/db-core/src/main/kotlin/com/pida/storage/db/core/district/DistrictCoreRepository.kt
@@ -1,0 +1,34 @@
+package com.pida.storage.db.core.district
+
+import com.pida.place.District
+import com.pida.place.DistrictRepository
+import com.pida.support.geo.GeoJson
+import org.locationtech.jts.geom.Coordinate
+import org.locationtech.jts.geom.GeometryFactory
+import org.locationtech.jts.geom.PrecisionModel
+import org.springframework.stereotype.Repository
+
+@Repository
+class DistrictCoreRepository(
+    private val districtJpaRepository: DistrictJpaRepository,
+) : DistrictRepository {
+    companion object {
+        private val GEOMETRY_FACTORY = GeometryFactory(PrecisionModel(), 4326)
+    }
+
+    override fun saveAll(districts: List<District>) {
+        val entities =
+            districts.map {
+                val point = it.pinPoint as GeoJson.Point
+                DistrictEntity(
+                    sido = it.sido,
+                    sigungu = it.sigungu,
+                    eupmyeondonggu = it.eupmyeondonggu,
+                    eupmyeonridong = it.eupmyeonridong,
+                    ri = it.ri,
+                    pinPoint = GEOMETRY_FACTORY.createPoint(Coordinate(point.coordinates[0], point.coordinates[1])),
+                )
+            }
+        districtJpaRepository.saveAll(entities)
+    }
+}

--- a/pida-storage/db-core/src/main/kotlin/com/pida/storage/db/core/district/DistrictCustomRepository.kt
+++ b/pida-storage/db-core/src/main/kotlin/com/pida/storage/db/core/district/DistrictCustomRepository.kt
@@ -21,21 +21,24 @@ class DistrictCustomRepository(
                     .whereAnd(
                         path(DistrictEntity::deletedAt).isNull(),
                         or(
+                            path(DistrictEntity::sido).like(pattern),
                             path(DistrictEntity::sigungu).like(pattern),
                             path(DistrictEntity::eupmyeondonggu).like(pattern),
                             path(DistrictEntity::eupmyeonridong).like(pattern),
                             path(DistrictEntity::ri).like(pattern),
                         ),
                     ).orderBy(
-                        caseWhen(path(DistrictEntity::sigungu).like(pattern))
+                        caseWhen(path(DistrictEntity::sido).like(pattern))
                             .then(value(1))
-                            .`when`(path(DistrictEntity::eupmyeondonggu).like(pattern))
+                            .`when`(path(DistrictEntity::sigungu).like(pattern))
                             .then(value(2))
-                            .`when`(path(DistrictEntity::eupmyeonridong).like(pattern))
+                            .`when`(path(DistrictEntity::eupmyeondonggu).like(pattern))
                             .then(value(3))
-                            .`when`(path(DistrictEntity::ri).like(pattern))
+                            .`when`(path(DistrictEntity::eupmyeonridong).like(pattern))
                             .then(value(4))
-                            .`else`(value(5))
+                            .`when`(path(DistrictEntity::ri).like(pattern))
+                            .then(value(5))
+                            .`else`(value(6))
                             .asc(),
                     )
             }

--- a/pida-storage/db-core/src/main/kotlin/com/pida/storage/db/core/district/DistrictCustomRepository.kt
+++ b/pida-storage/db-core/src/main/kotlin/com/pida/storage/db/core/district/DistrictCustomRepository.kt
@@ -1,0 +1,45 @@
+package com.pida.storage.db.core.district
+
+import com.linecorp.kotlinjdsl.dsl.jpql.jpql
+import com.linecorp.kotlinjdsl.render.RenderContext
+import com.linecorp.kotlinjdsl.support.spring.data.jpa.extension.createQuery
+import jakarta.persistence.EntityManager
+import org.springframework.stereotype.Repository
+
+@Repository
+class DistrictCustomRepository(
+    private val entityManager: EntityManager,
+    private val jdslRenderContext: RenderContext,
+) {
+    fun searchByKeyword(keyword: String): List<DistrictEntity> {
+        val pattern = "$keyword%" // B-tree index 활용을 위한 접두사 일치 패턴
+
+        val query =
+            jpql {
+                select(entity(DistrictEntity::class))
+                    .from(entity(DistrictEntity::class))
+                    .whereAnd(
+                        path(DistrictEntity::deletedAt).isNull(),
+                        or(
+                            path(DistrictEntity::sigungu).like(pattern),
+                            path(DistrictEntity::eupmyeondonggu).like(pattern),
+                            path(DistrictEntity::eupmyeonridong).like(pattern),
+                            path(DistrictEntity::ri).like(pattern),
+                        ),
+                    ).orderBy(
+                        caseWhen(path(DistrictEntity::sigungu).like(pattern))
+                            .then(value(1))
+                            .`when`(path(DistrictEntity::eupmyeondonggu).like(pattern))
+                            .then(value(2))
+                            .`when`(path(DistrictEntity::eupmyeonridong).like(pattern))
+                            .then(value(3))
+                            .`when`(path(DistrictEntity::ri).like(pattern))
+                            .then(value(4))
+                            .`else`(value(5))
+                            .asc(),
+                    )
+            }
+
+        return entityManager.createQuery(query, jdslRenderContext).resultList
+    }
+}

--- a/pida-storage/db-core/src/main/kotlin/com/pida/storage/db/core/district/DistrictEntity.kt
+++ b/pida-storage/db-core/src/main/kotlin/com/pida/storage/db/core/district/DistrictEntity.kt
@@ -8,11 +8,20 @@ import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
+import jakarta.persistence.Index
 import jakarta.persistence.Table
 import org.locationtech.jts.geom.Point
 
 @Entity
-@Table(name = "t_district")
+@Table(
+    name = "t_district",
+    indexes = [
+        Index(name = "idx_district_sigungu", columnList = "sigungu"),
+        Index(name = "idx_district_eupmyeondonggu", columnList = "eupmyeondonggu"),
+        Index(name = "idx_district_eupmyeonridong", columnList = "eupmyeonridong"),
+        Index(name = "idx_district_ri", columnList = "ri"),
+    ],
+)
 class DistrictEntity(
     @Enumerated(value = EnumType.STRING)
     @Column(columnDefinition = "varchar(50)")

--- a/pida-storage/db-core/src/main/kotlin/com/pida/storage/db/core/district/DistrictEntity.kt
+++ b/pida-storage/db-core/src/main/kotlin/com/pida/storage/db/core/district/DistrictEntity.kt
@@ -16,6 +16,7 @@ import org.locationtech.jts.geom.Point
 @Table(
     name = "t_district",
     indexes = [
+        Index(name = "idx_district_sido", columnList = "sido"),
         Index(name = "idx_district_sigungu", columnList = "sigungu"),
         Index(name = "idx_district_eupmyeondonggu", columnList = "eupmyeondonggu"),
         Index(name = "idx_district_eupmyeonridong", columnList = "eupmyeonridong"),
@@ -23,15 +24,16 @@ import org.locationtech.jts.geom.Point
     ],
 )
 class DistrictEntity(
-    @Enumerated(value = EnumType.STRING)
-    @Column(columnDefinition = "varchar(50)")
-    val sido: Region,
-    val sigungu: String,
+    val sido: String,
+    val sigungu: String?,
     val eupmyeondonggu: String?,
     val eupmyeonridong: String?,
     val ri: String?,
     @Column(columnDefinition = "geometry(Point, 4326)")
     val pinPoint: Point,
+    @Enumerated(value = EnumType.STRING)
+    @Column(columnDefinition = "varchar(50)")
+    val region: Region,
 ) : BaseEntity() {
     fun toDistrict(): District =
         District(
@@ -42,5 +44,6 @@ class DistrictEntity(
             eupmyeonridong = eupmyeonridong,
             ri = ri,
             pinPoint = GeoJson.Point(listOf(pinPoint.x, pinPoint.y)),
+            region = region,
         )
 }

--- a/pida-storage/db-core/src/main/kotlin/com/pida/storage/db/core/district/DistrictEntity.kt
+++ b/pida-storage/db-core/src/main/kotlin/com/pida/storage/db/core/district/DistrictEntity.kt
@@ -1,0 +1,37 @@
+package com.pida.storage.db.core.district
+
+import com.pida.place.District
+import com.pida.storage.db.core.support.BaseEntity
+import com.pida.support.geo.GeoJson
+import com.pida.support.geo.Region
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Table
+import org.locationtech.jts.geom.Point
+
+@Entity
+@Table(name = "t_district")
+class DistrictEntity(
+    @Enumerated(value = EnumType.STRING)
+    @Column(columnDefinition = "varchar(50)")
+    val sido: Region,
+    val sigungu: String,
+    val eupmyeondonggu: String?,
+    val eupmyeonridong: String?,
+    val ri: String?,
+    @Column(columnDefinition = "geometry(Point, 4326)")
+    val pinPoint: Point,
+) : BaseEntity() {
+    fun toDistrict(): District =
+        District(
+            id = id!!,
+            sido = sido,
+            sigungu = sigungu,
+            eupmyeondonggu = eupmyeondonggu,
+            eupmyeonridong = eupmyeonridong,
+            ri = ri,
+            pinPoint = GeoJson.Point(listOf(pinPoint.x, pinPoint.y)),
+        )
+}

--- a/pida-storage/db-core/src/main/kotlin/com/pida/storage/db/core/district/DistrictJpaRepository.kt
+++ b/pida-storage/db-core/src/main/kotlin/com/pida/storage/db/core/district/DistrictJpaRepository.kt
@@ -1,0 +1,5 @@
+package com.pida.storage.db.core.district
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface DistrictJpaRepository : JpaRepository<DistrictEntity, Long>

--- a/pida-storage/db-core/src/main/kotlin/com/pida/storage/db/core/landmark/LandmarkCoreRepository.kt
+++ b/pida-storage/db-core/src/main/kotlin/com/pida/storage/db/core/landmark/LandmarkCoreRepository.kt
@@ -1,8 +1,8 @@
 package com.pida.storage.db.core.landmark
 
-import com.pida.landmark.Landmark
-import com.pida.landmark.LandmarkRepository
-import com.pida.landmark.NewLandmark
+import com.pida.place.Landmark
+import com.pida.place.LandmarkRepository
+import com.pida.place.NewLandmark
 import org.locationtech.jts.geom.Coordinate
 import org.locationtech.jts.geom.GeometryFactory
 import org.locationtech.jts.geom.PrecisionModel

--- a/pida-storage/db-core/src/main/kotlin/com/pida/storage/db/core/landmark/LandmarkEntity.kt
+++ b/pida-storage/db-core/src/main/kotlin/com/pida/storage/db/core/landmark/LandmarkEntity.kt
@@ -1,6 +1,6 @@
 package com.pida.storage.db.core.landmark
 
-import com.pida.landmark.Landmark
+import com.pida.place.Landmark
 import com.pida.storage.db.core.support.BaseEntity
 import com.pida.support.geo.GeoJson
 import com.pida.support.geo.Region


### PR DESCRIPTION
## 🌱 관련 이슈
- close #87

## 📌 작업 내용 및 특이 사항

- 행정구역(District) 도메인 모델링
- Landmark + District 포함한 `place` 패키지 구성
- 랜드마크 및 벚꽃길 검색 API에 행정구역 검색 포함
- coroutineScope 사용하여 각 장소 검색 병렬 요청

## 📝 참고

- 검색 시 행정구역은 최대 2개, 랜드마크는 최대 5개 포함
- 행정구역 데이터 셋은 노션에 기재
- `/api/v1/place/search`로 검색 API 엔드포인트 변경됨
- 지하철 우선 검색 대응 필요

## 📌 체크 리스트
<!-- 
    조건을 만족하셨다면 공백 대신 x 를 넣어주세요.
    ex:
    - [x] ~~
    - [ ] ~~
-->
- [ ] 리뷰어를 추가하셨나요 ?
- [ ] 변경사항에 대해 충분히 설명하고 있나요 ?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified place search endpoint returning districts, landmarks, and flower spots.
  * POST /places to persist district data and searchable district records.

* **Refactor**
  * Consolidated separate searches into a single place-search flow.
  * Replaced standalone flower-spot search with the unified place search.

* **Performance**
  * Added caching-backed district and flower-spot lookups for faster repeated searches.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->