### PR TITLE
[Fix] Configure resource limits to fix development server timeout

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -10,6 +10,14 @@ services:
       - ~/.env
     depends_on:
       - redis
+    deploy:
+      resources:
+        limits:
+          cpus: '0.80'
+          memory: 768M
+        reservations:
+          cpus: '0.20'
+          memory: 256M
   redis:
     image: redis:7.2-alpine
     container_name: p-local-redis
@@ -26,3 +34,11 @@ services:
       interval: 5s
       timeout: 3s
       retries: 10
+    deploy:
+      resources:
+        limits:
+          cpus: '0.20'
+          memory: 64M
+        reservations:
+          cpus: '0.10'
+          memory: 32M


### PR DESCRIPTION
## 🌱 관련 이슈
- close #92 

## 📌 작업 내용 및 특이 사항

- 메모리 부족 문제로 인한 개발 서버 타임아웃 도커 리소스 제한으로 해결합니다
- 애플리케이션 최대 768M + 로컬 레디스 최대 64MB로 리소스 제한

## 📝 참고

<img width="1019" height="508" alt="스크린샷 2026-02-02 22 27 23" src="https://github.com/user-attachments/assets/d8af7347-c808-477c-9458-df549115a8a2" />
<img width="1063" height="552" alt="스크린샷 2026-02-02 22 27 44" src="https://github.com/user-attachments/assets/3fa06ccb-5409-49ab-9724-bada0fe2f934" />

- 현재 애플리케이션 서버가 메모리 대부분을 점유할 수 있음 --> OOM kill로 이어질 수 있음
- https://docs.docker.com/reference/compose-file/deploy/#resources

## 📌 체크 리스트
<!-- 
    조건을 만족하셨다면 공백 대신 x 를 넣어주세요.
    ex:
    - [x] ~~
    - [ ] ~~
-->
- [ ] 리뷰어를 추가하셨나요 ?
- [ ] 변경사항에 대해 충분히 설명하고 있나요 ?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Configured resource allocation settings with CPU and memory limits and reservations for backend and caching services to ensure optimal system performance and application stability.
  * These infrastructure updates establish boundaries for resource usage, prevent contention between services, and improve overall reliability during peak loads and high-traffic scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->