### PR TITLE
[Feature] Integrate Sentry with Opentelemetry agent to send server error alert

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,6 +13,7 @@ plugins {
 	alias(libs.plugins.asciidoctor.convert) apply false
 	alias(libs.plugins.epages.restdocs.api.spec) apply false
 	alias(libs.plugins.hidetake.swagger.generator) apply false
+	alias(libs.plugins.sentry.jvm.gradle) apply false
 }
 
 allprojects {

--- a/docker/DockerfileDev
+++ b/docker/DockerfileDev
@@ -1,9 +1,16 @@
+FROM alpine:latest AS agent-downloader
+RUN wget -O /sentry-opentelemetry-agent.jar https://get.sentry.io/sentry-opentelemetry-agent.jar
+
 FROM amazoncorretto:21
 ENV TZ="Asia/Seoul"
 
-RUN mkdir -p /service/pida
+RUN mkdir -p /service/pida /opt/sentry
+COPY --from=agent-downloader /sentry-opentelemetry-agent.jar /opt/sentry/agent.jar
 COPY pida-core/core-api/build/libs/core-api-0.0.1.jar /service/pida/core-api-0.0.1.jar
 
 EXPOSE 8080
 
-CMD java -jar -Xmx2048m /service/pida/core-api-0.0.1.jar
+CMD java \
+    -javaagent:/opt/sentry/agent.jar \
+    -Dsentry.auto.init=false \
+    -jar -Xmx2048m /service/pida/core-api-0.0.1.jar

--- a/docker/DockerfileDev
+++ b/docker/DockerfileDev
@@ -13,4 +13,5 @@ EXPOSE 8080
 CMD java \
     -javaagent:/opt/sentry/agent.jar \
     -Dsentry.auto.init=false \
-    -jar -Xmx2048m /service/pida/core-api-0.0.1.jar
+    -Xmx2048m \
+    -jar /service/pida/core-api-0.0.1.jar

--- a/docker/DockerfileProd
+++ b/docker/DockerfileProd
@@ -1,15 +1,20 @@
+FROM alpine:latest AS agent-downloader
+RUN wget -O /sentry-opentelemetry-agent.jar https://get.sentry.io/sentry-opentelemetry-agent.jar
+
 FROM amazoncorretto:21
 ENV TZ="Asia/Seoul"
 
 ARG PROFILE
 ENV PROFILE=${PROFILE}
 
-RUN mkdir -p /service/pida
-
+RUN mkdir -p /service/pida /opt/sentry
+COPY --from=agent-downloader /sentry-opentelemetry-agent.jar /opt/sentry/agent.jar
 COPY pida-core/core-api/build/libs/core-api-0.0.1.jar /service/pida/core-api-0.0.1.jar
 
 EXPOSE 8080
 
 CMD java \
+    -javaagent:/opt/sentry/agent.jar \
+    -Dsentry.auto.init=false \
     -Dspring.profiles.active=${PROFILE} \
     -jar /service/pida/core-api-0.0.1.jar

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,7 +37,7 @@ hidetake_swagger_generator = "2.18.2"
 swaggerVersion = "2.8.5"
 
 # Sentry version
-sentry = "7.3.0"
+sentry = "8.31.0"
 sentry_gradle = "6.0.0"
 
 # AWS version

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -189,6 +189,7 @@ epages_restdocs_api_spec_restassured = { module = "com.epages:restdocs-api-spec-
 micrometer_tracing_bridge_brave = { module = "io.micrometer:micrometer-tracing-bridge-brave" }
 micrometer_registry_prometheus = { module = "io.micrometer:micrometer-registry-prometheus" }
 sentry_spring_boot_starter_jakarta = { module = "io.sentry:sentry-spring-boot-starter-jakarta", version.ref = "sentry" }
+sentry_opentelemetry_agent = { module = "io.sentry:sentry-opentelemetry-agent", version.ref = "sentry" }
 slf4j = { module = "org.slf4j:slf4j-api", version = "2.0.9" }
 
 # AWS Libraries

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,6 +38,7 @@ swaggerVersion = "2.8.5"
 
 # Sentry version
 sentry = "7.3.0"
+sentry_gradle = "6.0.0"
 
 # AWS version
 aws = "2.40.13"
@@ -78,6 +79,9 @@ ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }
 # Spring Plugins
 spring_boot = { id = "org.springframework.boot", version.ref = "spring_boot" }
 spring_dependency_management = { id = "io.spring.dependency-management", version.ref = "spring_dependency_management" }
+
+# Sentry Plugin
+sentry_jvm_gradle = { id = "io.sentry.jvm.gradle", version.ref = "sentry_gradle" }
 
 # Api-Docs Plugins
 asciidoctor_convert = { id = "org.asciidoctor.jvm.convert", version.ref = "asciidoctor_convert" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -184,6 +184,7 @@ epages_restdocs_api_spec_restassured = { module = "com.epages:restdocs-api-spec-
 # Monitoring & Logging Libraries
 micrometer_tracing_bridge_brave = { module = "io.micrometer:micrometer-tracing-bridge-brave" }
 micrometer_registry_prometheus = { module = "io.micrometer:micrometer-registry-prometheus" }
+sentry_spring_boot_starter_jakarta = { module = "io.sentry:sentry-spring-boot-starter-jakarta", version.ref = "sentry" }
 slf4j = { module = "org.slf4j:slf4j-api", version = "2.0.9" }
 
 # AWS Libraries

--- a/pida-core/core-api/build.gradle.kts
+++ b/pida-core/core-api/build.gradle.kts
@@ -11,6 +11,8 @@ sentry {
     authToken.set(System.getenv("SENTRY_AUTH_TOKEN"))
 }
 
+val sentryAgent: Configuration by configurations.creating
+
 tasks.getByName("bootJar") {
     enabled = true
 }
@@ -19,7 +21,18 @@ tasks.getByName("jar") {
     enabled = false
 }
 
+tasks.register<Copy>("copySentryAgent") {
+    from(sentryAgent)
+    into(layout.buildDirectory.dir("agent"))
+    rename { "sentry-opentelemetry-agent.jar" }
+}
+
+tasks.named("build") {
+    dependsOn("copySentryAgent")
+}
+
 dependencies {
+    sentryAgent(libs.sentry.opentelemetry.agent)
     implementation(libs.spring.boot.starter.web)
     implementation(libs.spring.boot.starter.aop)
     implementation(libs.spring.boot.starter.validation)

--- a/pida-core/core-api/build.gradle.kts
+++ b/pida-core/core-api/build.gradle.kts
@@ -2,10 +2,12 @@ plugins {
     id("io.sentry.jvm.gradle")
 }
 
+val hasSentryToken = System.getenv("SENTRY_AUTH_TOKEN") != null
+
 sentry {
-    includeSourceContext.set(true)
+    includeSourceContext.set(hasSentryToken)
     org.set("pida-za")
-    projectName.set("java-spring-boot")
+    projectName.set("pida")
     authToken.set(System.getenv("SENTRY_AUTH_TOKEN"))
 }
 

--- a/pida-core/core-api/build.gradle.kts
+++ b/pida-core/core-api/build.gradle.kts
@@ -1,3 +1,14 @@
+plugins {
+    id("io.sentry.jvm.gradle")
+}
+
+sentry {
+    includeSourceContext.set(true)
+    org.set("pida-za")
+    projectName.set("java-spring-boot")
+    authToken.set(System.getenv("SENTRY_AUTH_TOKEN"))
+}
+
 tasks.getByName("bootJar") {
     enabled = true
 }

--- a/pida-supports/monitoring/build.gradle.kts
+++ b/pida-supports/monitoring/build.gradle.kts
@@ -2,4 +2,5 @@ dependencies {
     implementation(libs.spring.boot.starter.actuator)
     implementation(libs.micrometer.registry.prometheus)
     implementation(libs.sentry.spring.boot.starter.jakarta)
+    implementation(project(":pida-core:core-domain"))
 }

--- a/pida-supports/monitoring/build.gradle.kts
+++ b/pida-supports/monitoring/build.gradle.kts
@@ -1,4 +1,5 @@
 dependencies {
     implementation(libs.spring.boot.starter.actuator)
     implementation(libs.micrometer.registry.prometheus)
+    implementation(libs.sentry.spring.boot.starter.jakarta)
 }

--- a/pida-supports/monitoring/src/main/kotlin/com/pida/monitoring/sentry/SentryFingerprintCallback.kt
+++ b/pida-supports/monitoring/src/main/kotlin/com/pida/monitoring/sentry/SentryFingerprintCallback.kt
@@ -1,0 +1,44 @@
+package com.pida.monitoring.sentry
+
+import com.pida.support.error.AuthenticationErrorException
+import com.pida.support.error.ErrorException
+import io.sentry.Hint
+import io.sentry.SentryEvent
+import io.sentry.SentryOptions
+import org.springframework.stereotype.Component
+
+@Component
+class SentryFingerprintCallback : SentryOptions.BeforeSendCallback {
+    override fun execute(
+        event: SentryEvent,
+        hint: Hint,
+    ): SentryEvent {
+        val exception = event.throwable ?: return event
+
+        val fingerprint = resolveFingerprint(exception)
+        if (fingerprint != null) {
+            event.fingerprints = fingerprint
+        }
+
+        return event
+    }
+
+    private fun resolveFingerprint(exception: Throwable): List<String>? =
+        when (exception) {
+            is ErrorException ->
+                listOf(
+                    "ErrorException",
+                    exception.errorType.kind.name,
+                    exception.errorType.name,
+                )
+
+            is AuthenticationErrorException ->
+                listOf(
+                    "AuthenticationErrorException",
+                    exception.authenticationErrorType.kind.name,
+                    exception.authenticationErrorType.name,
+                )
+
+            else -> null
+        }
+}

--- a/pida-supports/monitoring/src/main/resources/monitoring.yml
+++ b/pida-supports/monitoring/src/main/resources/monitoring.yml
@@ -11,7 +11,6 @@ sentry:
   dsn: ${SENTRY_DSN}
   traces-sample-rate: 1.0
   environment: ${SPRING_PROFILES_ACTIVE:local}
-  send-default-pii: true
   exception-resolver-order: -2147483648
   logging:
     minimum-event-level: error

--- a/pida-supports/monitoring/src/main/resources/monitoring.yml
+++ b/pida-supports/monitoring/src/main/resources/monitoring.yml
@@ -12,3 +12,7 @@ sentry:
   traces-sample-rate: 1.0
   environment: ${SPRING_PROFILES_ACTIVE:local}
   send-default-pii: true
+  exception-resolver-order: -2147483648
+  logging:
+    minimum-event-level: error
+    minimum-breadcrumb-level: info

--- a/pida-supports/monitoring/src/main/resources/monitoring.yml
+++ b/pida-supports/monitoring/src/main/resources/monitoring.yml
@@ -6,3 +6,8 @@ management:
   health:
     defaults:
       enabled: false
+
+sentry:
+  dsn: ${SENTRY_DSN}
+  traces-sample-rate: 1.0
+  environment: ${SPRING_PROFILES_ACTIVE:local}

--- a/pida-supports/monitoring/src/main/resources/monitoring.yml
+++ b/pida-supports/monitoring/src/main/resources/monitoring.yml
@@ -11,3 +11,4 @@ sentry:
   dsn: ${SENTRY_DSN}
   traces-sample-rate: 1.0
   environment: ${SPRING_PROFILES_ACTIVE:local}
+  send-default-pii: true

--- a/pida-supports/monitoring/src/main/resources/monitoring.yml
+++ b/pida-supports/monitoring/src/main/resources/monitoring.yml
@@ -16,3 +16,11 @@ sentry:
   logging:
     minimum-event-level: error
     minimum-breadcrumb-level: info
+---
+spring:
+  config:
+    activate:
+      on-profile: prod
+
+sentry:
+  traces-sample-rate: 0.1


### PR DESCRIPTION
## 🌱 관련 이슈
- close #111

## 📌 작업 내용 및 특이 사항

- Sentry 의존성 추가
- Sentry와 Opentelemetry agent 연동
- Opentelemetry 에이전트 도입을 위한 Docker 멀티스테이지 빌드 전환
- BeforeSendCallback에 fingerprint 설정하여 예외 그룹핑
- 새로운 익셉션 발생 시 디스코드 알림

## 📝 참고

- 우선적으로 dev 배포 후, 추가 설정이 필요할 수도 있음

## 📌 체크 리스트
<!-- 
    조건을 만족하셨다면 공백 대신 x 를 넣어주세요.
    ex:
    - [x] ~~
    - [ ] ~~
-->
- [ ] 리뷰어를 추가하셨나요 ?
- [ ] 변경사항에 대해 충분히 설명하고 있나요 ?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Integrated Sentry error monitoring and distributed tracing.
  * Added OpenTelemetry agent to container images to enable agent-based telemetry.
  * Implemented intelligent error fingerprinting for improved grouping.
  * Added prod-specific Sentry sampling override (traces-sample-rate 0.1).

* **Chores**
  * Updated Sentry to 8.31.0 and introduced a Sentry Gradle plugin reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->