### PR TITLE
[Fix] Update Sentry Opentelemetry agent download URL in Dockerfiles

### DIFF
--- a/docker/DockerfileDev
+++ b/docker/DockerfileDev
@@ -1,5 +1,5 @@
 FROM alpine:latest AS agent-downloader
-RUN wget -O /sentry-opentelemetry-agent.jar https://get.sentry.io/sentry-opentelemetry-agent.jar
+RUN wget -O /sentry-opentelemetry-agent.jar https://repo1.maven.org/maven2/io/sentry/sentry-opentelemetry-agent/8.31.0/sentry-opentelemetry-agent-8.31.0.jar
 
 FROM amazoncorretto:21
 ENV TZ="Asia/Seoul"

--- a/docker/DockerfileProd
+++ b/docker/DockerfileProd
@@ -1,5 +1,5 @@
 FROM alpine:latest AS agent-downloader
-RUN wget -O /sentry-opentelemetry-agent.jar https://get.sentry.io/sentry-opentelemetry-agent.jar
+RUN wget -O /sentry-opentelemetry-agent.jar https://repo1.maven.org/maven2/io/sentry/sentry-opentelemetry-agent/8.31.0/sentry-opentelemetry-agent-8.31.0.jar
 
 FROM amazoncorretto:21
 ENV TZ="Asia/Seoul"


### PR DESCRIPTION
## 🌱 관련 이슈
- close #

## 📌 작업 내용 및 특이 사항

- Dockerfile에서 Sentry Opentelemetry agent 다운로드 URL을 수정합니다.

## 📝 참고

- 

## 📌 체크 리스트
<!-- 
    조건을 만족하셨다면 공백 대신 x 를 넣어주세요.
    ex:
    - [x] ~~
    - [ ] ~~
-->
- [ ] 리뷰어를 추가하셨나요 ?
- [ ] 변경사항에 대해 충분히 설명하고 있나요 ?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned Sentry OpenTelemetry agent to version 8.31.0 across all deployment environments for consistent and reliable builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->