### PR TITLE
[Refactor] Improvement Sentry dashboard configurations

### DIFF
--- a/pida-core/core-api/src/main/kotlin/com/pida/presentation/v1/HealthController.kt
+++ b/pida-core/core-api/src/main/kotlin/com/pida/presentation/v1/HealthController.kt
@@ -3,6 +3,9 @@ package com.pida.presentation.v1
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import java.time.LocalDateTime
 
@@ -13,7 +16,25 @@ class HealthController {
     @Operation(summary = "서버 상태 확인", description = "서버 상태를 확인합니다.")
     fun healthCheck(): PongResponse = PongResponse(LocalDateTime.now())
 
+    @PostMapping("/sentry-test")
+    @Operation(summary = "Sentry 알림 테스트", description = "Sentry 알림 확인을 위해 의도적으로 RuntimeException을 발생시킵니다.")
+    fun sentryTest(
+        @RequestParam(required = false) message: String?,
+        @RequestBody(required = false) body: SentryTestRequest?,
+    ): Nothing {
+        throw RuntimeException(
+            "Sentry 테스트 에러 발생! " +
+                "param.message=$message, " +
+                "body=$body",
+        )
+    }
+
     data class PongResponse(
         val now: LocalDateTime,
+    )
+
+    data class SentryTestRequest(
+        val key: String? = null,
+        val value: String? = null,
     )
 }

--- a/pida-core/core-api/src/main/kotlin/com/pida/presentation/v1/HealthController.kt
+++ b/pida-core/core-api/src/main/kotlin/com/pida/presentation/v1/HealthController.kt
@@ -21,13 +21,12 @@ class HealthController {
     fun sentryTest(
         @RequestParam(required = false) message: String?,
         @RequestBody(required = false) body: SentryTestRequest?,
-    ): Nothing {
+    ): Nothing =
         throw RuntimeException(
             "Sentry 테스트 에러 발생! " +
                 "param.message=$message, " +
                 "body=$body",
         )
-    }
 
     data class PongResponse(
         val now: LocalDateTime,

--- a/pida-supports/monitoring/src/main/resources/monitoring.yml
+++ b/pida-supports/monitoring/src/main/resources/monitoring.yml
@@ -10,7 +10,7 @@ management:
 sentry:
   dsn: ${SENTRY_DSN}
   traces-sample-rate: 1.0
-  environment: ${SPRING_PROFILES_ACTIVE:local}
+  environment: ${spring.profiles.active:local}
   exception-resolver-order: -2147483648
   logging:
     minimum-event-level: error

--- a/pida-supports/monitoring/src/main/resources/monitoring.yml
+++ b/pida-supports/monitoring/src/main/resources/monitoring.yml
@@ -13,6 +13,8 @@ sentry:
   environment: ${spring.profiles.active:local}
   send-default-pii: true
   max-request-body-size: always
+  profile-session-sample-rate: 1.0
+  profile-lifecycle: trace
   exception-resolver-order: -2147483648
   logging:
     minimum-event-level: error
@@ -25,4 +27,5 @@ spring:
 
 sentry:
   traces-sample-rate: 0.1
+  profile-session-sample-rate: 0.1
   send-default-pii: false

--- a/pida-supports/monitoring/src/main/resources/monitoring.yml
+++ b/pida-supports/monitoring/src/main/resources/monitoring.yml
@@ -11,6 +11,8 @@ sentry:
   dsn: ${SENTRY_DSN}
   traces-sample-rate: 1.0
   environment: ${spring.profiles.active:local}
+  send-default-pii: true
+  max-request-body-size: always
   exception-resolver-order: -2147483648
   logging:
     minimum-event-level: error
@@ -23,3 +25,4 @@ spring:
 
 sentry:
   traces-sample-rate: 0.1
+  send-default-pii: false


### PR DESCRIPTION
## 🌱 관련 이슈
- close #116 

## 📌 작업 내용 및 특이 사항

- Sentry 알림 테스트를 위한 POST /sentry-test API 추가
- Sentry environment 설정이 Spring profiles와 동기화되지 않아 일괄 production으로 분류되던 문제 수정 
- Sentry 이벤트에 request body 및 PII 정보가 포함되도록 send-default-pii, max-request-body-size 설정 추가
- Sentry에서 CPU flamegraph 확인할 수 있도록 profile-session-sample-rate 설정 추가

## 📝 참고

- dev 환경에서 opentelemetry-agent가 span 별로 trace 추적 하고 있는지 확인 필요

## 📌 체크 리스트
<!-- 
    조건을 만족하셨다면 공백 대신 x 를 넣어주세요.
    ex:
    - [x] ~~
    - [ ] ~~
-->
- [x] 리뷰어를 추가하셨나요 ?
- [ ] 변경사항에 대해 충분히 설명하고 있나요 ?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added testing capabilities for error monitoring systems validation.
  * Enhanced monitoring infrastructure with improved error tracking, performance profiling, and detailed diagnostic information collection.
  * Updated monitoring configuration to optimize reliability tracking and insights across different deployment environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->