### PR TITLE
[Feature] Categorires Event, Cafe All API

### DIFF
--- a/pida-core/core-api/src/main/kotlin/com/pida/presentation/v2/category/CategoryController.kt
+++ b/pida-core/core-api/src/main/kotlin/com/pida/presentation/v2/category/CategoryController.kt
@@ -2,14 +2,17 @@ package com.pida.presentation.v2.category
 
 import com.pida.category.MapCategoryFacade
 import com.pida.category.MapCategoryService
+import com.pida.flowerspot.FlowerSpotLocation
 import com.pida.presentation.v2.annotation.ApiV2Controller
 import com.pida.presentation.v2.category.response.MapCategoryAllResponse
 import com.pida.presentation.v2.category.response.MapCategoryItemAllResponse
 import com.pida.presentation.v2.category.response.MapCategoryResponse
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestParam
 
 @Tag(name = "🗂️ Category API", description = "카테고리 관련 API")
 @ApiV2Controller
@@ -24,12 +27,26 @@ class CategoryController(
         return MapCategoryAllResponse.of(categories.map { MapCategoryResponse.from(it) })
     }
 
-    @Operation(summary = "카테고리별 데이터 조회", description = "카테고리 ID에 해당하는 데이터 목록을 조회합니다.")
+    @Operation(summary = "카테고리별 데이터 조회", description = "카테고리 ID에 해당하는 데이터 목록을 조회합니다. 위경도가 모두 전달되면 해당 범위로 필터링합니다.")
     @GetMapping("/categories/{categoryId}/items")
     suspend fun categoryItemFindAll(
         @PathVariable categoryId: Long,
+        @RequestParam @Parameter(name = "swLat", description = "남서쪽 위도") swLat: Double?,
+        @RequestParam @Parameter(name = "swLng", description = "남서쪽 경도") swLng: Double?,
+        @RequestParam @Parameter(name = "neLat", description = "북동쪽 위도") neLat: Double?,
+        @RequestParam @Parameter(name = "neLng", description = "북동쪽 경도") neLng: Double?,
     ): MapCategoryItemAllResponse {
-        val categoryItems = mapCategoryFacade.readAllByCategoryId(categoryId)
+        val categoryItems =
+            mapCategoryFacade.readAllByCategoryId(
+                categoryId = categoryId,
+                location =
+                    FlowerSpotLocation(
+                        swLat = swLat,
+                        swLng = swLng,
+                        neLat = neLat,
+                        neLng = neLng,
+                    ),
+            )
         return MapCategoryItemAllResponse.from(categoryItems)
     }
 }

--- a/pida-core/core-api/src/main/kotlin/com/pida/presentation/v2/category/CategoryController.kt
+++ b/pida-core/core-api/src/main/kotlin/com/pida/presentation/v2/category/CategoryController.kt
@@ -1,22 +1,35 @@
 package com.pida.presentation.v2.category
 
+import com.pida.category.MapCategoryFacade
 import com.pida.category.MapCategoryService
 import com.pida.presentation.v2.annotation.ApiV2Controller
 import com.pida.presentation.v2.category.response.MapCategoryAllResponse
+import com.pida.presentation.v2.category.response.MapCategoryItemAllResponse
 import com.pida.presentation.v2.category.response.MapCategoryResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 
 @Tag(name = "🗂️ Category API", description = "카테고리 관련 API")
 @ApiV2Controller
 class CategoryController(
     private val mapCategoryService: MapCategoryService,
+    private val mapCategoryFacade: MapCategoryFacade,
 ) {
     @Operation(summary = "카테고리 전체 조회", description = "카테고리 목록을 전체 조회합니다.")
     @GetMapping("/categories")
     suspend fun categoryFindAll(): MapCategoryAllResponse {
         val categories = mapCategoryService.findAll()
         return MapCategoryAllResponse.of(categories.map { MapCategoryResponse.from(it) })
+    }
+
+    @Operation(summary = "카테고리별 데이터 조회", description = "카테고리 ID에 해당하는 데이터 목록을 조회합니다.")
+    @GetMapping("/categories/{categoryId}/items")
+    suspend fun categoryItemFindAll(
+        @PathVariable categoryId: Long,
+    ): MapCategoryItemAllResponse {
+        val categoryItems = mapCategoryFacade.readAllByCategoryId(categoryId)
+        return MapCategoryItemAllResponse.from(categoryItems)
     }
 }

--- a/pida-core/core-api/src/main/kotlin/com/pida/presentation/v2/category/response/MapCategoryItemResponse.kt
+++ b/pida-core/core-api/src/main/kotlin/com/pida/presentation/v2/category/response/MapCategoryItemResponse.kt
@@ -1,0 +1,103 @@
+package com.pida.presentation.v2.category.response
+
+import com.pida.category.CategoryLabel
+import com.pida.category.MapCategoryItem
+import com.pida.category.MapCategoryItems
+import com.pida.support.geo.GeoJson
+import com.pida.support.geo.Region
+import io.swagger.v3.oas.annotations.media.ArraySchema
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDate
+
+@Schema(description = "카테고리별 데이터 목록 응답")
+data class MapCategoryItemAllResponse(
+    @field:Schema(description = "카테고리 ID", example = "1")
+    val categoryId: Long,
+    @field:Schema(description = "카테고리 라벨", example = "EVENT")
+    val categoryLabel: CategoryLabel,
+    @field:ArraySchema(
+        schema = Schema(implementation = MapCategoryItemResponse::class),
+        arraySchema = Schema(description = "카테고리별 데이터 목록"),
+    )
+    val list: List<MapCategoryItemResponse>,
+) {
+    companion object {
+        fun from(mapCategoryItems: MapCategoryItems) =
+            MapCategoryItemAllResponse(
+                categoryId = mapCategoryItems.categoryId,
+                categoryLabel = mapCategoryItems.categoryLabel,
+                list = mapCategoryItems.list.map { MapCategoryItemResponse.from(it) },
+            )
+    }
+}
+
+@Schema(description = "카테고리별 데이터 응답")
+data class MapCategoryItemResponse(
+    @field:Schema(description = "데이터 ID", example = "1")
+    val id: Long,
+    @field:Schema(description = "이름", example = "여의도 봄꽃축제")
+    val name: String,
+    @field:Schema(description = "주소", example = "서울특별시 영등포구 여의서로 330")
+    val address: String?,
+    @field:Schema(description = "설명", example = "벚꽃 명소 인근 카페")
+    val description: String?,
+    @field:Schema(
+        description = "핀 포인트 정보 (GeoJson)",
+        example = """
+        {
+          "type": "Point",
+          "coordinates": [126.9340, 37.5284]
+        }
+    """,
+    )
+    val pinPoint: GeoJson,
+    @field:Schema(description = "지역", example = "SEOUL")
+    val region: Region,
+    @field:Schema(
+        description = "축제 홈페이지 URL (EVENT인 경우에만 포함)",
+        example = "https://example.com/festival",
+        requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+    )
+    val homepageUrl: String?,
+    @field:Schema(
+        description = "카페 지도 URL (CAFE인 경우에만 포함)",
+        example = "https://place.map.kakao.com/123456",
+        requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+    )
+    val mapUrl: String?,
+    @field:Schema(
+        description = "축제 시작일 (EVENT인 경우에만 포함)",
+        example = "2026-03-20",
+        requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+    )
+    val startDate: LocalDate?,
+    @field:Schema(
+        description = "축제 종료일 (EVENT인 경우에만 포함)",
+        example = "2026-03-30",
+        requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+    )
+    val endDate: LocalDate?,
+    @field:Schema(
+        description = "벚꽃길 ID (CAFE인 경우에만 포함)",
+        example = "15",
+        requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+    )
+    val flowerSpotId: Long?,
+) {
+    companion object {
+        fun from(mapCategoryItem: MapCategoryItem) =
+            MapCategoryItemResponse(
+                id = mapCategoryItem.id,
+                name = mapCategoryItem.name,
+                address = mapCategoryItem.address,
+                description = mapCategoryItem.description,
+                pinPoint = mapCategoryItem.pinPoint,
+                region = mapCategoryItem.region,
+                homepageUrl = mapCategoryItem.homepageUrl,
+                mapUrl = mapCategoryItem.mapUrl,
+                startDate = mapCategoryItem.startDate,
+                endDate = mapCategoryItem.endDate,
+                flowerSpotId = mapCategoryItem.flowerSpotId,
+            )
+    }
+}

--- a/pida-core/core-domain/src/main/kotlin/com/pida/category/CafeCategoryItemReadStrategy.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/category/CafeCategoryItemReadStrategy.kt
@@ -1,0 +1,38 @@
+package com.pida.category
+
+import com.pida.flowerspot.FlowerSpotCafeFinder
+import com.pida.flowerspot.FlowerSpotLocation
+import com.pida.flowerspot.hasBounds
+import org.springframework.stereotype.Component
+
+@Component
+class CafeCategoryItemReadStrategy(
+    private val flowerSpotCafeFinder: FlowerSpotCafeFinder,
+) : MapCategoryItemReadStrategy {
+    override val categoryLabel: CategoryLabel = CategoryLabel.CAFE
+
+    override suspend fun read(
+        categoryId: Long,
+        location: FlowerSpotLocation,
+    ): List<MapCategoryItem> {
+        val cafes =
+            if (location.hasBounds()) {
+                flowerSpotCafeFinder.readAllByLocation(location)
+            } else {
+                flowerSpotCafeFinder.readAll()
+            }
+
+        return cafes.map { cafe ->
+            MapCategoryItem(
+                id = cafe.id,
+                name = cafe.name,
+                address = cafe.address,
+                description = cafe.description,
+                pinPoint = cafe.pinPoint,
+                region = cafe.region,
+                mapUrl = cafe.mapUrl,
+                flowerSpotId = cafe.flowerSpotId,
+            )
+        }
+    }
+}

--- a/pida-core/core-domain/src/main/kotlin/com/pida/category/EventCategoryItemReadStrategy.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/category/EventCategoryItemReadStrategy.kt
@@ -1,0 +1,39 @@
+package com.pida.category
+
+import com.pida.flowerevent.FlowerEventFinder
+import com.pida.flowerspot.FlowerSpotLocation
+import com.pida.flowerspot.hasBounds
+import org.springframework.stereotype.Component
+
+@Component
+class EventCategoryItemReadStrategy(
+    private val flowerEventFinder: FlowerEventFinder,
+) : MapCategoryItemReadStrategy {
+    override val categoryLabel: CategoryLabel = CategoryLabel.EVENT
+
+    override suspend fun read(
+        categoryId: Long,
+        location: FlowerSpotLocation,
+    ): List<MapCategoryItem> {
+        val events =
+            if (location.hasBounds()) {
+                flowerEventFinder.readAllByCategoryIdAndLocation(categoryId, location)
+            } else {
+                flowerEventFinder.readAllByCategoryId(categoryId)
+            }
+
+        return events.map { event ->
+            MapCategoryItem(
+                id = event.id,
+                name = event.name,
+                address = event.address,
+                description = null,
+                pinPoint = event.pinPoint,
+                region = event.region,
+                homepageUrl = event.homepageUrl,
+                startDate = event.startDate,
+                endDate = event.endDate,
+            )
+        }
+    }
+}

--- a/pida-core/core-domain/src/main/kotlin/com/pida/category/MapCategoryFacade.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/category/MapCategoryFacade.kt
@@ -1,53 +1,36 @@
 package com.pida.category
 
-import com.pida.flowerevent.FlowerEventFinder
-import com.pida.flowerspot.FlowerSpotCafeFinder
+import com.pida.flowerspot.FlowerSpotLocation
 import org.springframework.stereotype.Service
 
 @Service
 class MapCategoryFacade(
     private val mapCategoryService: MapCategoryService,
-    private val flowerEventFinder: FlowerEventFinder,
-    private val flowerSpotCafeFinder: FlowerSpotCafeFinder,
+    categoryItemReadStrategies: List<MapCategoryItemReadStrategy>,
 ) {
-    suspend fun readAllByCategoryId(categoryId: Long): MapCategoryItems {
-        val category = mapCategoryService.readBy(categoryId)
-        val items =
-            when (category.categoryLabel) {
-                CategoryLabel.EVENT ->
-                    flowerEventFinder.readAllByCategoryId(category.id).map { event ->
-                        MapCategoryItem(
-                            id = event.id,
-                            name = event.name,
-                            address = event.address,
-                            description = null,
-                            pinPoint = event.pinPoint,
-                            region = event.region,
-                            homepageUrl = event.homepageUrl,
-                            startDate = event.startDate,
-                            endDate = event.endDate,
-                        )
-                    }
+    private val strategiesByCategory =
+        categoryItemReadStrategies.associateBy(MapCategoryItemReadStrategy::categoryLabel)
 
-                CategoryLabel.CAFE ->
-                    flowerSpotCafeFinder.readAll().map { cafe ->
-                        MapCategoryItem(
-                            id = cafe.id,
-                            name = cafe.name,
-                            address = cafe.address,
-                            description = cafe.description,
-                            pinPoint = cafe.pinPoint,
-                            region = cafe.region,
-                            mapUrl = cafe.mapUrl,
-                            flowerSpotId = cafe.flowerSpotId,
-                        )
-                    }
+    init {
+        require(categoryItemReadStrategies.size == strategiesByCategory.size) {
+            "Map category item strategy must be unique by category label."
+        }
+    }
+
+    suspend fun readAllByCategoryId(
+        categoryId: Long,
+        location: FlowerSpotLocation,
+    ): MapCategoryItems {
+        val category = mapCategoryService.readBy(categoryId)
+        val strategy =
+            requireNotNull(strategiesByCategory[category.categoryLabel]) {
+                "No map category item strategy for ${category.categoryLabel}"
             }
 
         return MapCategoryItems(
             categoryId = category.id,
             categoryLabel = category.categoryLabel,
-            list = items,
+            list = strategy.read(category.id, location),
         )
     }
 }

--- a/pida-core/core-domain/src/main/kotlin/com/pida/category/MapCategoryFacade.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/category/MapCategoryFacade.kt
@@ -1,0 +1,53 @@
+package com.pida.category
+
+import com.pida.flowerevent.FlowerEventFinder
+import com.pida.flowerspot.FlowerSpotCafeFinder
+import org.springframework.stereotype.Service
+
+@Service
+class MapCategoryFacade(
+    private val mapCategoryService: MapCategoryService,
+    private val flowerEventFinder: FlowerEventFinder,
+    private val flowerSpotCafeFinder: FlowerSpotCafeFinder,
+) {
+    suspend fun readAllByCategoryId(categoryId: Long): MapCategoryItems {
+        val category = mapCategoryService.readBy(categoryId)
+        val items =
+            when (category.categoryLabel) {
+                CategoryLabel.EVENT ->
+                    flowerEventFinder.readAllByCategoryId(category.id).map { event ->
+                        MapCategoryItem(
+                            id = event.id,
+                            name = event.name,
+                            address = event.address,
+                            description = null,
+                            pinPoint = event.pinPoint,
+                            region = event.region,
+                            homepageUrl = event.homepageUrl,
+                            startDate = event.startDate,
+                            endDate = event.endDate,
+                        )
+                    }
+
+                CategoryLabel.CAFE ->
+                    flowerSpotCafeFinder.readAll().map { cafe ->
+                        MapCategoryItem(
+                            id = cafe.id,
+                            name = cafe.name,
+                            address = cafe.address,
+                            description = cafe.description,
+                            pinPoint = cafe.pinPoint,
+                            region = cafe.region,
+                            mapUrl = cafe.mapUrl,
+                            flowerSpotId = cafe.flowerSpotId,
+                        )
+                    }
+            }
+
+        return MapCategoryItems(
+            categoryId = category.id,
+            categoryLabel = category.categoryLabel,
+            list = items,
+        )
+    }
+}

--- a/pida-core/core-domain/src/main/kotlin/com/pida/category/MapCategoryFacade.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/category/MapCategoryFacade.kt
@@ -8,6 +8,14 @@ class MapCategoryFacade(
     private val mapCategoryService: MapCategoryService,
     categoryItemReadStrategies: List<MapCategoryItemReadStrategy>,
 ) {
+    /**
+     * 카테고리 ID로 카테고리를 조회한 뒤,
+     * 해당 카테고리 라벨에 매핑된 전략(Strategy)을 통해 아이템 목록을 반환한다.
+     *
+     * - [MapCategoryService.readBy]로 카테고리 엔티티를 조회
+     * - [strategiesByCategory]에서 라벨에 맞는 전략을 꺼냄 (없으면 예외)
+     * - 전략의 [MapCategoryItemReadStrategy.read]를 호출하여 아이템 목록 생성
+     */
     private val strategiesByCategory =
         categoryItemReadStrategies.associateBy(MapCategoryItemReadStrategy::categoryLabel)
 

--- a/pida-core/core-domain/src/main/kotlin/com/pida/category/MapCategoryItem.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/category/MapCategoryItem.kt
@@ -1,0 +1,25 @@
+package com.pida.category
+
+import com.pida.support.geo.GeoJson
+import com.pida.support.geo.Region
+import java.time.LocalDate
+
+data class MapCategoryItems(
+    val categoryId: Long,
+    val categoryLabel: CategoryLabel,
+    val list: List<MapCategoryItem>,
+)
+
+data class MapCategoryItem(
+    val id: Long,
+    val name: String,
+    val address: String?,
+    val description: String?,
+    val pinPoint: GeoJson,
+    val region: Region,
+    val homepageUrl: String? = null,
+    val mapUrl: String? = null,
+    val startDate: LocalDate? = null,
+    val endDate: LocalDate? = null,
+    val flowerSpotId: Long? = null,
+)

--- a/pida-core/core-domain/src/main/kotlin/com/pida/category/MapCategoryItemReadStrategy.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/category/MapCategoryItemReadStrategy.kt
@@ -1,0 +1,12 @@
+package com.pida.category
+
+import com.pida.flowerspot.FlowerSpotLocation
+
+interface MapCategoryItemReadStrategy {
+    val categoryLabel: CategoryLabel
+
+    suspend fun read(
+        categoryId: Long,
+        location: FlowerSpotLocation,
+    ): List<MapCategoryItem>
+}

--- a/pida-core/core-domain/src/main/kotlin/com/pida/category/MapCategoryRepository.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/category/MapCategoryRepository.kt
@@ -1,5 +1,7 @@
 package com.pida.category
 
 interface MapCategoryRepository {
+    suspend fun findBy(id: Long): MapCategory
+
     suspend fun findAll(): List<MapCategory>
 }

--- a/pida-core/core-domain/src/main/kotlin/com/pida/category/MapCategoryService.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/category/MapCategoryService.kt
@@ -6,5 +6,7 @@ import org.springframework.stereotype.Service
 class MapCategoryService(
     private val mapCategoryRepository: MapCategoryRepository,
 ) {
+    suspend fun readBy(categoryId: Long): MapCategory = mapCategoryRepository.findBy(categoryId)
+
     suspend fun findAll(): List<MapCategory> = mapCategoryRepository.findAll()
 }

--- a/pida-core/core-domain/src/main/kotlin/com/pida/flowerevent/FlowerEventFinder.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/flowerevent/FlowerEventFinder.kt
@@ -1,5 +1,6 @@
 package com.pida.flowerevent
 
+import com.pida.flowerspot.FlowerSpotLocation
 import org.springframework.stereotype.Component
 
 @Component
@@ -7,4 +8,9 @@ class FlowerEventFinder(
     private val flowerEventRepository: FlowerEventRepository,
 ) {
     suspend fun readAllByCategoryId(categoryId: Long): List<FlowerEvent> = flowerEventRepository.findAllByCategoryId(categoryId)
+
+    suspend fun readAllByCategoryIdAndLocation(
+        categoryId: Long,
+        location: FlowerSpotLocation,
+    ): List<FlowerEvent> = flowerEventRepository.findAllByCategoryIdAndLocation(categoryId, location)
 }

--- a/pida-core/core-domain/src/main/kotlin/com/pida/flowerevent/FlowerEventFinder.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/flowerevent/FlowerEventFinder.kt
@@ -1,0 +1,10 @@
+package com.pida.flowerevent
+
+import org.springframework.stereotype.Component
+
+@Component
+class FlowerEventFinder(
+    private val flowerEventRepository: FlowerEventRepository,
+) {
+    suspend fun readAllByCategoryId(categoryId: Long): List<FlowerEvent> = flowerEventRepository.findAllByCategoryId(categoryId)
+}

--- a/pida-core/core-domain/src/main/kotlin/com/pida/flowerevent/FlowerEventRepository.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/flowerevent/FlowerEventRepository.kt
@@ -1,5 +1,12 @@
 package com.pida.flowerevent
 
+import com.pida.flowerspot.FlowerSpotLocation
+
 interface FlowerEventRepository {
     suspend fun findAllByCategoryId(categoryId: Long): List<FlowerEvent>
+
+    suspend fun findAllByCategoryIdAndLocation(
+        categoryId: Long,
+        location: FlowerSpotLocation,
+    ): List<FlowerEvent>
 }

--- a/pida-core/core-domain/src/main/kotlin/com/pida/flowerevent/FlowerEventRepository.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/flowerevent/FlowerEventRepository.kt
@@ -1,0 +1,5 @@
+package com.pida.flowerevent
+
+interface FlowerEventRepository {
+    suspend fun findAllByCategoryId(categoryId: Long): List<FlowerEvent>
+}

--- a/pida-core/core-domain/src/main/kotlin/com/pida/flowerspot/FlowerSpotCafeFinder.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/flowerspot/FlowerSpotCafeFinder.kt
@@ -8,6 +8,8 @@ class FlowerSpotCafeFinder(
 ) {
     suspend fun readBy(cafeId: Long): FlowerSpotCafe = flowerSpotCafeRepository.findBy(cafeId)
 
+    suspend fun readAll(): List<FlowerSpotCafe> = flowerSpotCafeRepository.findAll()
+
     suspend fun readAllByFlowerSpotId(flowerSpotId: Long): List<FlowerSpotCafe> =
         flowerSpotCafeRepository.findAllByFlowerSpotId(flowerSpotId)
 }

--- a/pida-core/core-domain/src/main/kotlin/com/pida/flowerspot/FlowerSpotCafeFinder.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/flowerspot/FlowerSpotCafeFinder.kt
@@ -10,6 +10,8 @@ class FlowerSpotCafeFinder(
 
     suspend fun readAll(): List<FlowerSpotCafe> = flowerSpotCafeRepository.findAll()
 
+    suspend fun readAllByLocation(location: FlowerSpotLocation): List<FlowerSpotCafe> = flowerSpotCafeRepository.findAllByLocation(location)
+
     suspend fun readAllByFlowerSpotId(flowerSpotId: Long): List<FlowerSpotCafe> =
         flowerSpotCafeRepository.findAllByFlowerSpotId(flowerSpotId)
 }

--- a/pida-core/core-domain/src/main/kotlin/com/pida/flowerspot/FlowerSpotCafeRepository.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/flowerspot/FlowerSpotCafeRepository.kt
@@ -3,5 +3,7 @@ package com.pida.flowerspot
 interface FlowerSpotCafeRepository {
     suspend fun findBy(cafeId: Long): FlowerSpotCafe
 
+    suspend fun findAll(): List<FlowerSpotCafe>
+
     suspend fun findAllByFlowerSpotId(flowerSpotId: Long): List<FlowerSpotCafe>
 }

--- a/pida-core/core-domain/src/main/kotlin/com/pida/flowerspot/FlowerSpotCafeRepository.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/flowerspot/FlowerSpotCafeRepository.kt
@@ -5,5 +5,7 @@ interface FlowerSpotCafeRepository {
 
     suspend fun findAll(): List<FlowerSpotCafe>
 
+    suspend fun findAllByLocation(location: FlowerSpotLocation): List<FlowerSpotCafe>
+
     suspend fun findAllByFlowerSpotId(flowerSpotId: Long): List<FlowerSpotCafe>
 }

--- a/pida-core/core-domain/src/main/kotlin/com/pida/flowerspot/FlowerSpotLocation.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/flowerspot/FlowerSpotLocation.kt
@@ -7,4 +7,4 @@ data class FlowerSpotLocation(
     val neLng: Double?,
 )
 
-fun FlowerSpotLocation.isNotSet(): Boolean = swLat != null && swLng != null && neLat != null && neLng != null
+fun FlowerSpotLocation.hasBounds(): Boolean = swLat != null && swLng != null && neLat != null && neLng != null

--- a/pida-core/core-domain/src/main/kotlin/com/pida/flowerspot/FlowerSpotService.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/flowerspot/FlowerSpotService.kt
@@ -13,8 +13,8 @@ class FlowerSpotService(
     ): List<FlowerSpot> {
         val condition =
             when {
-                !location.isNotSet() && region == null -> FindFlowerSpotPolicyCondition.All
-                !location.isNotSet() -> FindFlowerSpotPolicyCondition.ByRegion(region!!)
+                !location.hasBounds() && region == null -> FindFlowerSpotPolicyCondition.All
+                !location.hasBounds() -> FindFlowerSpotPolicyCondition.ByRegion(region!!)
                 region == null -> FindFlowerSpotPolicyCondition.ByLocation(location)
                 else -> FindFlowerSpotPolicyCondition.ByRegionAndLocation(region, location)
             }

--- a/pida-core/core-domain/src/test/kotlin/com/pida/category/CafeCategoryItemReadStrategyTest.kt
+++ b/pida-core/core-domain/src/test/kotlin/com/pida/category/CafeCategoryItemReadStrategyTest.kt
@@ -1,0 +1,71 @@
+package com.pida.category
+
+import com.pida.flowerspot.FlowerSpotCafe
+import com.pida.flowerspot.FlowerSpotCafeFinder
+import com.pida.flowerspot.FlowerSpotLocation
+import com.pida.support.geo.GeoJson
+import com.pida.support.geo.Region
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+
+class CafeCategoryItemReadStrategyTest {
+    @Test
+    fun `위치 정보가 없으면 전체 카페 조회를 사용한다`(): Unit =
+        runBlocking {
+            val flowerSpotCafeFinder = mockk<FlowerSpotCafeFinder>()
+            val strategy = CafeCategoryItemReadStrategy(flowerSpotCafeFinder)
+            val location = FlowerSpotLocation(swLat = null, swLng = null, neLat = null, neLng = null)
+            val cafe =
+                FlowerSpotCafe(
+                    id = 20L,
+                    flowerSpotId = 3L,
+                    name = "벚꽃뷰 카페",
+                    address = "서울특별시 송파구 석촌호수로 12",
+                    description = "석촌호수 근처 카페",
+                    pinPoint = GeoJson.Point(listOf(127.1040, 37.5070)),
+                    region = Region.SEOUL,
+                    mapUrl = "https://place.map.kakao.com/123456",
+                    deletedAt = null,
+                )
+
+            coEvery { flowerSpotCafeFinder.readAll() } returns listOf(cafe)
+
+            val result = strategy.read(2L, location)
+
+            result shouldHaveSize 1
+            result.first().id shouldBe 20L
+            result.first().flowerSpotId shouldBe 3L
+        }
+
+    @Test
+    fun `위치 정보가 있으면 위치 기반 카페 조회를 사용한다`(): Unit =
+        runBlocking {
+            val flowerSpotCafeFinder = mockk<FlowerSpotCafeFinder>()
+            val strategy = CafeCategoryItemReadStrategy(flowerSpotCafeFinder)
+            val location = FlowerSpotLocation(swLat = 37.4, swLng = 126.8, neLat = 37.6, neLng = 127.1)
+            val cafe =
+                FlowerSpotCafe(
+                    id = 21L,
+                    flowerSpotId = 4L,
+                    name = "호수뷰 카페",
+                    address = "서울특별시 송파구 잠실동",
+                    description = "호수 근처 카페",
+                    pinPoint = GeoJson.Point(listOf(127.1050, 37.5080)),
+                    region = Region.SEOUL,
+                    mapUrl = "https://place.map.kakao.com/654321",
+                    deletedAt = null,
+                )
+
+            coEvery { flowerSpotCafeFinder.readAllByLocation(location) } returns listOf(cafe)
+
+            val result = strategy.read(2L, location)
+
+            result shouldHaveSize 1
+            result.first().id shouldBe 21L
+            result.first().mapUrl shouldBe "https://place.map.kakao.com/654321"
+        }
+}

--- a/pida-core/core-domain/src/test/kotlin/com/pida/category/EventCategoryItemReadStrategyTest.kt
+++ b/pida-core/core-domain/src/test/kotlin/com/pida/category/EventCategoryItemReadStrategyTest.kt
@@ -1,0 +1,74 @@
+package com.pida.category
+
+import com.pida.flowerevent.FlowerEvent
+import com.pida.flowerevent.FlowerEventFinder
+import com.pida.flowerspot.FlowerSpotLocation
+import com.pida.support.geo.GeoJson
+import com.pida.support.geo.Region
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class EventCategoryItemReadStrategyTest {
+    @Test
+    fun `위치 정보가 없으면 전체 이벤트 조회를 사용한다`(): Unit =
+        runBlocking {
+            val flowerEventFinder = mockk<FlowerEventFinder>()
+            val strategy = EventCategoryItemReadStrategy(flowerEventFinder)
+            val location = FlowerSpotLocation(swLat = null, swLng = null, neLat = null, neLng = null)
+            val event =
+                FlowerEvent(
+                    id = 10L,
+                    name = "여의도 봄꽃축제",
+                    address = "서울특별시 영등포구 여의서로 330",
+                    pinPoint = GeoJson.Point(listOf(126.9340, 37.5284)),
+                    region = Region.SEOUL,
+                    homepageUrl = "https://example.com/festival",
+                    startDate = LocalDate.of(2026, 3, 20),
+                    endDate = LocalDate.of(2026, 3, 30),
+                    categoryId = 1L,
+                    deletedAt = null,
+                )
+
+            coEvery { flowerEventFinder.readAllByCategoryId(1L) } returns listOf(event)
+
+            val result = strategy.read(1L, location)
+
+            result shouldHaveSize 1
+            result.first().id shouldBe 10L
+            result.first().homepageUrl shouldBe "https://example.com/festival"
+        }
+
+    @Test
+    fun `위치 정보가 있으면 위치 기반 이벤트 조회를 사용한다`(): Unit =
+        runBlocking {
+            val flowerEventFinder = mockk<FlowerEventFinder>()
+            val strategy = EventCategoryItemReadStrategy(flowerEventFinder)
+            val location = FlowerSpotLocation(swLat = 37.4, swLng = 126.8, neLat = 37.6, neLng = 127.1)
+            val event =
+                FlowerEvent(
+                    id = 11L,
+                    name = "석촌호수 벚꽃축제",
+                    address = "서울특별시 송파구 잠실동",
+                    pinPoint = GeoJson.Point(listOf(127.1040, 37.5070)),
+                    region = Region.SEOUL,
+                    homepageUrl = "https://example.com/lake-festival",
+                    startDate = LocalDate.of(2026, 4, 1),
+                    endDate = LocalDate.of(2026, 4, 10),
+                    categoryId = 1L,
+                    deletedAt = null,
+                )
+
+            coEvery { flowerEventFinder.readAllByCategoryIdAndLocation(1L, location) } returns listOf(event)
+
+            val result = strategy.read(1L, location)
+
+            result shouldHaveSize 1
+            result.first().id shouldBe 11L
+            result.first().startDate shouldBe LocalDate.of(2026, 4, 1)
+        }
+}

--- a/pida-core/core-domain/src/test/kotlin/com/pida/category/MapCategoryFacadeTest.kt
+++ b/pida-core/core-domain/src/test/kotlin/com/pida/category/MapCategoryFacadeTest.kt
@@ -1,0 +1,124 @@
+package com.pida.category
+
+import com.pida.flowerevent.FlowerEvent
+import com.pida.flowerevent.FlowerEventFinder
+import com.pida.flowerspot.FlowerSpotCafe
+import com.pida.flowerspot.FlowerSpotCafeFinder
+import com.pida.support.geo.GeoJson
+import com.pida.support.geo.Region
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class MapCategoryFacadeTest {
+    @Test
+    fun `EVENT 카테고리는 축제 목록으로 매핑한다`(): Unit =
+        runBlocking {
+            val mapCategoryService = mockk<MapCategoryService>()
+            val flowerEventFinder = mockk<FlowerEventFinder>()
+            val flowerSpotCafeFinder = mockk<FlowerSpotCafeFinder>()
+            val service = MapCategoryFacade(mapCategoryService, flowerEventFinder, flowerSpotCafeFinder)
+
+            val category =
+                MapCategory(
+                    id = 1L,
+                    title = "벚꽃 축제",
+                    categoryLabel = CategoryLabel.EVENT,
+                    description = "벚꽃 축제 카테고리",
+                    deletedAt = null,
+                )
+            val event =
+                FlowerEvent(
+                    id = 10L,
+                    name = "여의도 봄꽃축제",
+                    address = "서울특별시 영등포구 여의서로 330",
+                    pinPoint = GeoJson.Point(listOf(126.9340, 37.5284)),
+                    region = Region.SEOUL,
+                    homepageUrl = "https://example.com/festival",
+                    startDate = LocalDate.of(2026, 3, 20),
+                    endDate = LocalDate.of(2026, 3, 30),
+                    categoryId = 1L,
+                    deletedAt = null,
+                )
+
+            coEvery { mapCategoryService.readBy(1L) } returns category
+            coEvery { flowerEventFinder.readAllByCategoryId(1L) } returns listOf(event)
+
+            val result = service.readAllByCategoryId(1L)
+
+            result.categoryId shouldBe 1L
+            result.categoryLabel shouldBe CategoryLabel.EVENT
+            result.list shouldHaveSize 1
+            result.list.first() shouldBe
+                MapCategoryItem(
+                    id = 10L,
+                    name = "여의도 봄꽃축제",
+                    address = "서울특별시 영등포구 여의서로 330",
+                    description = null,
+                    pinPoint = GeoJson.Point(listOf(126.9340, 37.5284)),
+                    region = Region.SEOUL,
+                    homepageUrl = "https://example.com/festival",
+                    mapUrl = null,
+                    startDate = LocalDate.of(2026, 3, 20),
+                    endDate = LocalDate.of(2026, 3, 30),
+                    flowerSpotId = null,
+                )
+        }
+
+    @Test
+    fun `CAFE 카테고리는 카페 목록으로 매핑한다`(): Unit =
+        runBlocking {
+            val mapCategoryService = mockk<MapCategoryService>()
+            val flowerEventFinder = mockk<FlowerEventFinder>()
+            val flowerSpotCafeFinder = mockk<FlowerSpotCafeFinder>()
+            val service = MapCategoryFacade(mapCategoryService, flowerEventFinder, flowerSpotCafeFinder)
+
+            val category =
+                MapCategory(
+                    id = 2L,
+                    title = "카페",
+                    categoryLabel = CategoryLabel.CAFE,
+                    description = "카페 카테고리",
+                    deletedAt = null,
+                )
+            val cafe =
+                FlowerSpotCafe(
+                    id = 20L,
+                    flowerSpotId = 3L,
+                    name = "벚꽃뷰 카페",
+                    address = "서울특별시 송파구 석촌호수로 12",
+                    description = "석촌호수 근처 카페",
+                    pinPoint = GeoJson.Point(listOf(127.1040, 37.5070)),
+                    region = Region.SEOUL,
+                    mapUrl = "https://place.map.kakao.com/123456",
+                    deletedAt = null,
+                )
+
+            coEvery { mapCategoryService.readBy(2L) } returns category
+            coEvery { flowerSpotCafeFinder.readAll() } returns listOf(cafe)
+
+            val result = service.readAllByCategoryId(2L)
+
+            result.categoryId shouldBe 2L
+            result.categoryLabel shouldBe CategoryLabel.CAFE
+            result.list shouldHaveSize 1
+            result.list.first() shouldBe
+                MapCategoryItem(
+                    id = 20L,
+                    name = "벚꽃뷰 카페",
+                    address = "서울특별시 송파구 석촌호수로 12",
+                    description = "석촌호수 근처 카페",
+                    pinPoint = GeoJson.Point(listOf(127.1040, 37.5070)),
+                    region = Region.SEOUL,
+                    homepageUrl = null,
+                    mapUrl = "https://place.map.kakao.com/123456",
+                    startDate = null,
+                    endDate = null,
+                    flowerSpotId = 3L,
+                )
+        }
+}

--- a/pida-core/core-domain/src/test/kotlin/com/pida/category/MapCategoryFacadeTest.kt
+++ b/pida-core/core-domain/src/test/kotlin/com/pida/category/MapCategoryFacadeTest.kt
@@ -1,14 +1,12 @@
 package com.pida.category
 
-import com.pida.flowerevent.FlowerEvent
-import com.pida.flowerevent.FlowerEventFinder
-import com.pida.flowerspot.FlowerSpotCafe
-import com.pida.flowerspot.FlowerSpotCafeFinder
+import com.pida.flowerspot.FlowerSpotLocation
 import com.pida.support.geo.GeoJson
 import com.pida.support.geo.Region
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
+import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Test
@@ -16,12 +14,16 @@ import java.time.LocalDate
 
 class MapCategoryFacadeTest {
     @Test
-    fun `EVENT 카테고리는 축제 목록으로 매핑한다`(): Unit =
+    fun `카테고리 라벨에 맞는 전략으로 목록을 조회한다`(): Unit =
         runBlocking {
             val mapCategoryService = mockk<MapCategoryService>()
-            val flowerEventFinder = mockk<FlowerEventFinder>()
-            val flowerSpotCafeFinder = mockk<FlowerSpotCafeFinder>()
-            val service = MapCategoryFacade(mapCategoryService, flowerEventFinder, flowerSpotCafeFinder)
+            val eventStrategy = mockk<MapCategoryItemReadStrategy>()
+            val cafeStrategy = mockk<MapCategoryItemReadStrategy>()
+
+            every { eventStrategy.categoryLabel } returns CategoryLabel.EVENT
+            every { cafeStrategy.categoryLabel } returns CategoryLabel.CAFE
+
+            val facade = MapCategoryFacade(mapCategoryService, listOf(eventStrategy, cafeStrategy))
 
             val category =
                 MapCategory(
@@ -31,29 +33,8 @@ class MapCategoryFacadeTest {
                     description = "벚꽃 축제 카테고리",
                     deletedAt = null,
                 )
-            val event =
-                FlowerEvent(
-                    id = 10L,
-                    name = "여의도 봄꽃축제",
-                    address = "서울특별시 영등포구 여의서로 330",
-                    pinPoint = GeoJson.Point(listOf(126.9340, 37.5284)),
-                    region = Region.SEOUL,
-                    homepageUrl = "https://example.com/festival",
-                    startDate = LocalDate.of(2026, 3, 20),
-                    endDate = LocalDate.of(2026, 3, 30),
-                    categoryId = 1L,
-                    deletedAt = null,
-                )
-
-            coEvery { mapCategoryService.readBy(1L) } returns category
-            coEvery { flowerEventFinder.readAllByCategoryId(1L) } returns listOf(event)
-
-            val result = service.readAllByCategoryId(1L)
-
-            result.categoryId shouldBe 1L
-            result.categoryLabel shouldBe CategoryLabel.EVENT
-            result.list shouldHaveSize 1
-            result.list.first() shouldBe
+            val location = FlowerSpotLocation(swLat = null, swLng = null, neLat = null, neLng = null)
+            val item =
                 MapCategoryItem(
                     id = 10L,
                     name = "여의도 봄꽃축제",
@@ -67,58 +48,37 @@ class MapCategoryFacadeTest {
                     endDate = LocalDate.of(2026, 3, 30),
                     flowerSpotId = null,
                 )
+
+            coEvery { mapCategoryService.readBy(1L) } returns category
+            coEvery { eventStrategy.read(1L, location) } returns listOf(item)
+
+            val result = facade.readAllByCategoryId(1L, location)
+
+            result.categoryId shouldBe 1L
+            result.categoryLabel shouldBe CategoryLabel.EVENT
+            result.list shouldHaveSize 1
+            result.list.first() shouldBe item
         }
 
     @Test
-    fun `CAFE 카테고리는 카페 목록으로 매핑한다`(): Unit =
+    fun `전략은 카테고리별로 하나만 등록할 수 있다`(): Unit =
         runBlocking {
             val mapCategoryService = mockk<MapCategoryService>()
-            val flowerEventFinder = mockk<FlowerEventFinder>()
-            val flowerSpotCafeFinder = mockk<FlowerSpotCafeFinder>()
-            val service = MapCategoryFacade(mapCategoryService, flowerEventFinder, flowerSpotCafeFinder)
+            val firstEventStrategy = mockk<MapCategoryItemReadStrategy>()
+            val secondEventStrategy = mockk<MapCategoryItemReadStrategy>()
 
-            val category =
-                MapCategory(
-                    id = 2L,
-                    title = "카페",
-                    categoryLabel = CategoryLabel.CAFE,
-                    description = "카페 카테고리",
-                    deletedAt = null,
-                )
-            val cafe =
-                FlowerSpotCafe(
-                    id = 20L,
-                    flowerSpotId = 3L,
-                    name = "벚꽃뷰 카페",
-                    address = "서울특별시 송파구 석촌호수로 12",
-                    description = "석촌호수 근처 카페",
-                    pinPoint = GeoJson.Point(listOf(127.1040, 37.5070)),
-                    region = Region.SEOUL,
-                    mapUrl = "https://place.map.kakao.com/123456",
-                    deletedAt = null,
-                )
+            every { firstEventStrategy.categoryLabel } returns CategoryLabel.EVENT
+            every { secondEventStrategy.categoryLabel } returns CategoryLabel.EVENT
 
-            coEvery { mapCategoryService.readBy(2L) } returns category
-            coEvery { flowerSpotCafeFinder.readAll() } returns listOf(cafe)
+            val exception =
+                kotlin
+                    .runCatching {
+                        MapCategoryFacade(
+                            mapCategoryService = mapCategoryService,
+                            categoryItemReadStrategies = listOf(firstEventStrategy, secondEventStrategy),
+                        )
+                    }.exceptionOrNull()
 
-            val result = service.readAllByCategoryId(2L)
-
-            result.categoryId shouldBe 2L
-            result.categoryLabel shouldBe CategoryLabel.CAFE
-            result.list shouldHaveSize 1
-            result.list.first() shouldBe
-                MapCategoryItem(
-                    id = 20L,
-                    name = "벚꽃뷰 카페",
-                    address = "서울특별시 송파구 석촌호수로 12",
-                    description = "석촌호수 근처 카페",
-                    pinPoint = GeoJson.Point(listOf(127.1040, 37.5070)),
-                    region = Region.SEOUL,
-                    homepageUrl = null,
-                    mapUrl = "https://place.map.kakao.com/123456",
-                    startDate = null,
-                    endDate = null,
-                    flowerSpotId = 3L,
-                )
+            exception?.message shouldBe "Map category item strategy must be unique by category label."
         }
 }

--- a/pida-storage/db-core/src/main/kotlin/com/pida/storage/db/core/category/MapCategoryCoreRepository.kt
+++ b/pida-storage/db-core/src/main/kotlin/com/pida/storage/db/core/category/MapCategoryCoreRepository.kt
@@ -2,6 +2,7 @@ package com.pida.storage.db.core.category
 
 import com.pida.category.MapCategory
 import com.pida.category.MapCategoryRepository
+import com.pida.storage.db.core.support.findByIdAndDeletedAtIsNullOrElseThrow
 import com.pida.support.tx.TransactionTemplates
 import com.pida.support.tx.coExecute
 import org.springframework.stereotype.Repository
@@ -11,10 +12,17 @@ class MapCategoryCoreRepository(
     private val mapCategoryJpaRepository: MapCategoryJpaRepository,
     private val tx: TransactionTemplates,
 ) : MapCategoryRepository {
+    override suspend fun findBy(id: Long): MapCategory =
+        tx.reader.coExecute {
+            mapCategoryJpaRepository
+                .findByIdAndDeletedAtIsNullOrElseThrow(id)
+                .toMapCategory()
+        }
+
     override suspend fun findAll(): List<MapCategory> =
         tx.reader.coExecute {
             mapCategoryJpaRepository
-                .findByDeletedAtIsNull()
+                .findByDeletedAtIsNullOrderByIdAsc()
                 .map { it.toMapCategory() }
         }
 }

--- a/pida-storage/db-core/src/main/kotlin/com/pida/storage/db/core/category/MapCategoryJpaRepository.kt
+++ b/pida-storage/db-core/src/main/kotlin/com/pida/storage/db/core/category/MapCategoryJpaRepository.kt
@@ -3,5 +3,5 @@ package com.pida.storage.db.core.category
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface MapCategoryJpaRepository : JpaRepository<MapCategoryEntity, Long> {
-    fun findByDeletedAtIsNull(): List<MapCategoryEntity>
+    fun findByDeletedAtIsNullOrderByIdAsc(): List<MapCategoryEntity>
 }

--- a/pida-storage/db-core/src/main/kotlin/com/pida/storage/db/core/flowerevent/FlowerEventCoreRepository.kt
+++ b/pida-storage/db-core/src/main/kotlin/com/pida/storage/db/core/flowerevent/FlowerEventCoreRepository.kt
@@ -2,6 +2,7 @@ package com.pida.storage.db.core.flowerevent
 
 import com.pida.flowerevent.FlowerEvent
 import com.pida.flowerevent.FlowerEventRepository
+import com.pida.flowerspot.FlowerSpotLocation
 import com.pida.support.tx.Tx
 import org.springframework.stereotype.Repository
 
@@ -14,5 +15,20 @@ class FlowerEventCoreRepository(
             flowerEventJpaRepository
                 .findByCategoryIdAndDeletedAtIsNullOrderByStartDateAscIdAsc(categoryId)
                 .map { it.toFlowerEvent() }
+        }
+
+    override suspend fun findAllByCategoryIdAndLocation(
+        categoryId: Long,
+        location: FlowerSpotLocation,
+    ): List<FlowerEvent> =
+        Tx.coReadable {
+            flowerEventJpaRepository
+                .findByCategoryIdWithinBoundsOrderByStartDateAscIdAsc(
+                    categoryId = categoryId,
+                    swLat = location.swLat!!,
+                    swLng = location.swLng!!,
+                    neLat = location.neLat!!,
+                    neLng = location.neLng!!,
+                ).map { it.toFlowerEvent() }
         }
 }

--- a/pida-storage/db-core/src/main/kotlin/com/pida/storage/db/core/flowerevent/FlowerEventCoreRepository.kt
+++ b/pida-storage/db-core/src/main/kotlin/com/pida/storage/db/core/flowerevent/FlowerEventCoreRepository.kt
@@ -1,0 +1,18 @@
+package com.pida.storage.db.core.flowerevent
+
+import com.pida.flowerevent.FlowerEvent
+import com.pida.flowerevent.FlowerEventRepository
+import com.pida.support.tx.Tx
+import org.springframework.stereotype.Repository
+
+@Repository
+class FlowerEventCoreRepository(
+    private val flowerEventJpaRepository: FlowerEventJpaRepository,
+) : FlowerEventRepository {
+    override suspend fun findAllByCategoryId(categoryId: Long): List<FlowerEvent> =
+        Tx.coReadable {
+            flowerEventJpaRepository
+                .findByCategoryIdAndDeletedAtIsNullOrderByStartDateAscIdAsc(categoryId)
+                .map { it.toFlowerEvent() }
+        }
+}

--- a/pida-storage/db-core/src/main/kotlin/com/pida/storage/db/core/flowerevent/FlowerEventJpaRepository.kt
+++ b/pida-storage/db-core/src/main/kotlin/com/pida/storage/db/core/flowerevent/FlowerEventJpaRepository.kt
@@ -1,0 +1,7 @@
+package com.pida.storage.db.core.flowerevent
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface FlowerEventJpaRepository : JpaRepository<FlowerEventEntity, Long> {
+    fun findByCategoryIdAndDeletedAtIsNullOrderByStartDateAscIdAsc(categoryId: Long): List<FlowerEventEntity>
+}

--- a/pida-storage/db-core/src/main/kotlin/com/pida/storage/db/core/flowerevent/FlowerEventJpaRepository.kt
+++ b/pida-storage/db-core/src/main/kotlin/com/pida/storage/db/core/flowerevent/FlowerEventJpaRepository.kt
@@ -1,7 +1,31 @@
 package com.pida.storage.db.core.flowerevent
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 
 interface FlowerEventJpaRepository : JpaRepository<FlowerEventEntity, Long> {
     fun findByCategoryIdAndDeletedAtIsNullOrderByStartDateAscIdAsc(categoryId: Long): List<FlowerEventEntity>
+
+    @Query(
+        """
+        SELECT *
+        FROM t_flower_event
+        WHERE category_id = :categoryId
+        AND ST_Contains(
+            ST_MakeEnvelope(:swLng, :swLat, :neLng, :neLat, 4326),
+            pin_point
+        )
+        AND deleted_at IS NULL
+        ORDER BY start_date ASC, id ASC
+        """,
+        nativeQuery = true,
+    )
+    fun findByCategoryIdWithinBoundsOrderByStartDateAscIdAsc(
+        @Param("categoryId") categoryId: Long,
+        @Param("swLat") swLat: Double,
+        @Param("swLng") swLng: Double,
+        @Param("neLat") neLat: Double,
+        @Param("neLng") neLng: Double,
+    ): List<FlowerEventEntity>
 }

--- a/pida-storage/db-core/src/main/kotlin/com/pida/storage/db/core/flowerspot/FlowerSpotCafeCoreRepository.kt
+++ b/pida-storage/db-core/src/main/kotlin/com/pida/storage/db/core/flowerspot/FlowerSpotCafeCoreRepository.kt
@@ -19,6 +19,13 @@ class FlowerSpotCafeCoreRepository(
                 .toFlowerSpotCafe()
         }
 
+    override suspend fun findAll(): List<FlowerSpotCafe> =
+        tx.reader.coExecute {
+            flowerSpotCafeJpaRepository
+                .findByDeletedAtIsNullOrderByIdAsc()
+                .map { it.toFlowerSpotCafe() }
+        }
+
     override suspend fun findAllByFlowerSpotId(flowerSpotId: Long): List<FlowerSpotCafe> =
         tx.reader.coExecute {
             flowerSpotCafeJpaRepository

--- a/pida-storage/db-core/src/main/kotlin/com/pida/storage/db/core/flowerspot/FlowerSpotCafeCoreRepository.kt
+++ b/pida-storage/db-core/src/main/kotlin/com/pida/storage/db/core/flowerspot/FlowerSpotCafeCoreRepository.kt
@@ -2,6 +2,7 @@ package com.pida.storage.db.core.flowerspot
 
 import com.pida.flowerspot.FlowerSpotCafe
 import com.pida.flowerspot.FlowerSpotCafeRepository
+import com.pida.flowerspot.FlowerSpotLocation
 import com.pida.storage.db.core.support.findByIdAndDeletedAtIsNullOrElseThrow
 import com.pida.support.tx.TransactionTemplates
 import com.pida.support.tx.coExecute
@@ -24,6 +25,17 @@ class FlowerSpotCafeCoreRepository(
             flowerSpotCafeJpaRepository
                 .findByDeletedAtIsNullOrderByIdAsc()
                 .map { it.toFlowerSpotCafe() }
+        }
+
+    override suspend fun findAllByLocation(location: FlowerSpotLocation): List<FlowerSpotCafe> =
+        tx.reader.coExecute {
+            flowerSpotCafeJpaRepository
+                .findWithinBoundsOrderByIdAsc(
+                    swLat = location.swLat!!,
+                    swLng = location.swLng!!,
+                    neLat = location.neLat!!,
+                    neLng = location.neLng!!,
+                ).map { it.toFlowerSpotCafe() }
         }
 
     override suspend fun findAllByFlowerSpotId(flowerSpotId: Long): List<FlowerSpotCafe> =

--- a/pida-storage/db-core/src/main/kotlin/com/pida/storage/db/core/flowerspot/FlowerSpotCafeJpaRepository.kt
+++ b/pida-storage/db-core/src/main/kotlin/com/pida/storage/db/core/flowerspot/FlowerSpotCafeJpaRepository.kt
@@ -3,5 +3,7 @@ package com.pida.storage.db.core.flowerspot
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface FlowerSpotCafeJpaRepository : JpaRepository<FlowerSpotCafeEntity, Long> {
+    fun findByDeletedAtIsNullOrderByIdAsc(): List<FlowerSpotCafeEntity>
+
     fun findByFlowerSpotIdAndDeletedAtIsNull(flowerSpotId: Long): List<FlowerSpotCafeEntity>
 }

--- a/pida-storage/db-core/src/main/kotlin/com/pida/storage/db/core/flowerspot/FlowerSpotCafeJpaRepository.kt
+++ b/pida-storage/db-core/src/main/kotlin/com/pida/storage/db/core/flowerspot/FlowerSpotCafeJpaRepository.kt
@@ -1,9 +1,31 @@
 package com.pida.storage.db.core.flowerspot
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 
 interface FlowerSpotCafeJpaRepository : JpaRepository<FlowerSpotCafeEntity, Long> {
     fun findByDeletedAtIsNullOrderByIdAsc(): List<FlowerSpotCafeEntity>
+
+    @Query(
+        """
+        SELECT *
+        FROM t_flower_spot_cafe
+        WHERE ST_Contains(
+            ST_MakeEnvelope(:swLng, :swLat, :neLng, :neLat, 4326),
+            pin_point
+        )
+        AND deleted_at IS NULL
+        ORDER BY id ASC
+        """,
+        nativeQuery = true,
+    )
+    fun findWithinBoundsOrderByIdAsc(
+        @Param("swLat") swLat: Double,
+        @Param("swLng") swLng: Double,
+        @Param("neLat") neLat: Double,
+        @Param("neLng") neLng: Double,
+    ): List<FlowerSpotCafeEntity>
 
     fun findByFlowerSpotIdAndDeletedAtIsNull(flowerSpotId: Long): List<FlowerSpotCafeEntity>
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #120 

## 📌 작업 내용 및 특이 사항

- 카테고리 별 데이터 조회 API
- 조회 시 카페/축제/벚꽃 장소에 따른 전략 패턴 구성으로 개선

## 📝 참고

- 

## 📌 체크 리스트
<!-- 
    조건을 만족하셨다면 공백 대신 x 를 넣어주세요.
    ex:
    - [x] ~~
    - [ ] ~~
-->
- [ ] 리뷰어를 추가하셨나요 ?
- [ ] 변경사항에 대해 충분히 설명하고 있나요 ?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New category items API endpoint: fetch items for a category with optional map bounds — returns names, addresses, descriptions, pinpoints, regions, URLs, and start/end dates.
  * Map listings expanded to include café and event items with location-aware filtering and consistent ordering.

* **Tests**
  * Added unit tests covering category item retrieval, mapping, uniqueness of strategies, and location-based behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->