### PR TITLE
[Feature] Expand category detail API with walking trail and thumbnail responses

### DIFF
--- a/pida-core/core-api/src/main/kotlin/com/pida/presentation/v2/category/CategoryController.kt
+++ b/pida-core/core-api/src/main/kotlin/com/pida/presentation/v2/category/CategoryController.kt
@@ -6,6 +6,7 @@ import com.pida.flowerspot.FlowerSpotLocation
 import com.pida.presentation.v2.annotation.ApiV2Controller
 import com.pida.presentation.v2.category.response.MapCategoryAllResponse
 import com.pida.presentation.v2.category.response.MapCategoryItemAllResponse
+import com.pida.presentation.v2.category.response.MapCategoryItemDetailResponse
 import com.pida.presentation.v2.category.response.MapCategoryResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
@@ -46,7 +47,20 @@ class CategoryController(
                         neLat = neLat,
                         neLng = neLng,
                     ),
-            )
+        )
         return MapCategoryItemAllResponse.from(categoryItems)
     }
+
+    @Operation(summary = "카테고리별 상세 조회", description = "카테고리 ID와 데이터 ID에 해당하는 상세 정보를 조회합니다.")
+    @GetMapping("/categories/{categoryId}/items/{itemId}")
+    suspend fun categoryItemFindDetail(
+        @PathVariable categoryId: Long,
+        @PathVariable itemId: Long,
+    ): MapCategoryItemDetailResponse =
+        MapCategoryItemDetailResponse.from(
+            mapCategoryFacade.readDetailByCategoryId(
+                categoryId = categoryId,
+                itemId = itemId,
+            ),
+        )
 }

--- a/pida-core/core-api/src/main/kotlin/com/pida/presentation/v2/category/CategoryController.kt
+++ b/pida-core/core-api/src/main/kotlin/com/pida/presentation/v2/category/CategoryController.kt
@@ -47,7 +47,7 @@ class CategoryController(
                         neLat = neLat,
                         neLng = neLng,
                     ),
-        )
+            )
         return MapCategoryItemAllResponse.from(categoryItems)
     }
 

--- a/pida-core/core-api/src/main/kotlin/com/pida/presentation/v2/category/response/MapCategoryItemResponse.kt
+++ b/pida-core/core-api/src/main/kotlin/com/pida/presentation/v2/category/response/MapCategoryItemResponse.kt
@@ -4,7 +4,9 @@ import com.fasterxml.jackson.annotation.JsonInclude
 import com.pida.blooming.BloomingStatus
 import com.pida.category.CategoryLabel
 import com.pida.category.MapCategoryItem
+import com.pida.category.MapCategoryItemDetail
 import com.pida.category.MapCategoryItems
+import com.pida.presentation.v1.blooming.response.BloomingDetailsResponse
 import com.pida.support.geo.GeoJson
 import com.pida.support.geo.Region
 import io.swagger.v3.oas.annotations.media.ArraySchema
@@ -44,6 +46,27 @@ data class MapCategoryItemResponse(
     val address: String?,
     @field:Schema(description = "설명", example = "벚꽃 명소 인근 카페")
     val description: String?,
+    @field:Schema(
+        description = "대표 썸네일 이미지 URL",
+        example = "https://cdn.example.com/event-thumbnail.jpg",
+        requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+    )
+    val thumbnailUrl: String?,
+    @field:Schema(
+        description = "라인 정보 (FLOWER_SPOT인 경우에만 포함)",
+        example = """
+        {
+          "type": "LineString",
+          "coordinates": [
+            [127.10079, 37.48809],
+            [127.10116, 37.48825],
+            [127.10221, 37.48852]
+          ]
+        }
+    """,
+        requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+    )
+    val geom: GeoJson?,
     @field:Schema(
         description = "핀 포인트 정보 (GeoJson)",
         example = """
@@ -87,7 +110,13 @@ data class MapCategoryItemResponse(
     )
     val flowerSpotId: Long?,
     @field:Schema(
-        description = "개화 상태 (EVENT인 경우에만 포함)",
+        description = "최근 방문 횟수 (CAFE, FLOWER_SPOT인 경우에만 포함)",
+        example = "12",
+        requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+    )
+    val recentlyVisitedCount: Long?,
+    @field:Schema(
+        description = "개화 상태 (EVENT, CAFE, FLOWER_SPOT에서 포함될 수 있음)",
         example = "BLOOMED",
         requiredMode = Schema.RequiredMode.NOT_REQUIRED,
     )
@@ -100,6 +129,8 @@ data class MapCategoryItemResponse(
                 name = mapCategoryItem.name,
                 address = mapCategoryItem.address,
                 description = mapCategoryItem.description,
+                thumbnailUrl = mapCategoryItem.thumbnailUrl,
+                geom = mapCategoryItem.geom,
                 pinPoint = mapCategoryItem.pinPoint,
                 region = mapCategoryItem.region,
                 homepageUrl = mapCategoryItem.homepageUrl,
@@ -107,7 +138,209 @@ data class MapCategoryItemResponse(
                 startDate = mapCategoryItem.startDate,
                 endDate = mapCategoryItem.endDate,
                 flowerSpotId = mapCategoryItem.flowerSpotId,
+                recentlyVisitedCount = mapCategoryItem.recentlyVisitedCount,
                 bloomingStatus = mapCategoryItem.bloomingStatus,
             )
     }
 }
+
+@Schema(description = "카테고리별 데이터 상세 응답")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class MapCategoryItemDetailResponse(
+    @field:Schema(description = "카테고리 ID", example = "1")
+    val categoryId: Long,
+    @field:Schema(description = "카테고리 라벨", example = "EVENT")
+    val categoryLabel: CategoryLabel,
+    @field:Schema(description = "카테고리 공통 상세 정보")
+    val common: MapCategoryItemCommonDetailResponse,
+    @field:Schema(description = "카테고리별 상세 정보")
+    val detail: MapCategoryItemSpecificDetailResponse,
+) {
+    companion object {
+        fun from(mapCategoryItemDetail: MapCategoryItemDetail): MapCategoryItemDetailResponse {
+            val item = mapCategoryItemDetail.item
+
+            return MapCategoryItemDetailResponse(
+                categoryId = mapCategoryItemDetail.categoryId,
+                categoryLabel = mapCategoryItemDetail.categoryLabel,
+                common =
+                    MapCategoryItemCommonDetailResponse(
+                        id = item.id,
+                        name = item.name,
+                        address = item.address,
+                        description = item.description,
+                        pinPoint = item.pinPoint,
+                        region = item.region,
+                        bloomingStatus = item.bloomingStatus,
+                        bloomingDetails = BloomingDetailsResponse.from(mapCategoryItemDetail.bloomingDetails),
+                    ),
+                detail =
+                    when (mapCategoryItemDetail.categoryLabel) {
+                        CategoryLabel.EVENT ->
+                            MapCategoryItemSpecificDetailResponse(
+                                event =
+                                    EventCategoryItemDetailPayloadResponse(
+                                        thumbnailUrl = item.thumbnailUrl,
+                                        homepageUrl = item.homepageUrl,
+                                        startDate = item.startDate,
+                                        endDate = item.endDate,
+                                    ),
+                            )
+
+                        CategoryLabel.CAFE ->
+                            MapCategoryItemSpecificDetailResponse(
+                                cafe =
+                                    CafeCategoryItemDetailPayloadResponse(
+                                        thumbnailUrl = item.thumbnailUrl,
+                                        mapUrl = item.mapUrl,
+                                        flowerSpotId = item.flowerSpotId,
+                                        recentlyVisitedCount = item.recentlyVisitedCount,
+                                    ),
+                            )
+
+                        CategoryLabel.FLOWER_SPOT ->
+                            MapCategoryItemSpecificDetailResponse(
+                                flowerSpot =
+                                    FlowerSpotCategoryItemDetailPayloadResponse(
+                                        geom = item.geom,
+                                        recentlyVisitedCount = item.recentlyVisitedCount,
+                                    ),
+                            )
+                    },
+            )
+        }
+    }
+}
+
+@Schema(description = "카테고리 공통 상세 응답")
+data class MapCategoryItemCommonDetailResponse(
+    @field:Schema(description = "데이터 ID", example = "1")
+    val id: Long,
+    @field:Schema(description = "이름", example = "여의도 봄꽃축제")
+    val name: String,
+    @field:Schema(description = "주소", example = "서울특별시 영등포구 여의서로 330")
+    val address: String?,
+    @field:Schema(description = "설명", example = "벚꽃 명소 인근 카페")
+    val description: String?,
+    @field:Schema(
+        description = "핀 포인트 정보 (GeoJson)",
+        example = """
+        {
+          "type": "Point",
+          "coordinates": [126.9340, 37.5284]
+        }
+    """,
+    )
+    val pinPoint: GeoJson,
+    @field:Schema(description = "지역", example = "SEOUL")
+    val region: Region,
+    @field:Schema(
+        description = "대표 개화 상태",
+        example = "BLOOMED",
+        requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+    )
+    val bloomingStatus: BloomingStatus?,
+    @field:Schema(description = "개화 상태 상세 정보")
+    val bloomingDetails: BloomingDetailsResponse,
+)
+
+@Schema(description = "카테고리별 상세 payload")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class MapCategoryItemSpecificDetailResponse(
+    @field:Schema(
+        description = "EVENT 상세 정보",
+        requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+    )
+    val event: EventCategoryItemDetailPayloadResponse? = null,
+    @field:Schema(
+        description = "CAFE 상세 정보",
+        requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+    )
+    val cafe: CafeCategoryItemDetailPayloadResponse? = null,
+    @field:Schema(
+        description = "FLOWER_SPOT 상세 정보",
+        requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+    )
+    val flowerSpot: FlowerSpotCategoryItemDetailPayloadResponse? = null,
+)
+
+@Schema(description = "이벤트 상세 정보")
+data class EventCategoryItemDetailPayloadResponse(
+    @field:Schema(
+        description = "대표 썸네일 이미지 URL",
+        example = "https://cdn.example.com/event-thumbnail.jpg",
+        requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+    )
+    val thumbnailUrl: String?,
+    @field:Schema(
+        description = "축제 홈페이지 URL",
+        example = "https://example.com/festival",
+        requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+    )
+    val homepageUrl: String?,
+    @field:Schema(
+        description = "축제 시작일",
+        example = "2026-03-20",
+        requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+    )
+    val startDate: LocalDate?,
+    @field:Schema(
+        description = "축제 종료일",
+        example = "2026-03-30",
+        requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+    )
+    val endDate: LocalDate?,
+)
+
+@Schema(description = "카페 상세 정보")
+data class CafeCategoryItemDetailPayloadResponse(
+    @field:Schema(
+        description = "대표 썸네일 이미지 URL",
+        example = "https://cdn.example.com/cafe-thumbnail.jpg",
+        requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+    )
+    val thumbnailUrl: String?,
+    @field:Schema(
+        description = "카페 지도 URL",
+        example = "https://place.map.kakao.com/123456",
+        requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+    )
+    val mapUrl: String?,
+    @field:Schema(
+        description = "연결된 벚꽃길 ID",
+        example = "15",
+        requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+    )
+    val flowerSpotId: Long?,
+    @field:Schema(
+        description = "최근 방문 횟수",
+        example = "12",
+        requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+    )
+    val recentlyVisitedCount: Long?,
+)
+
+@Schema(description = "산책길 상세 정보")
+data class FlowerSpotCategoryItemDetailPayloadResponse(
+    @field:Schema(
+        description = "라인 정보 (GeoJson)",
+        example = """
+        {
+          "type": "LineString",
+          "coordinates": [
+            [127.10079, 37.48809],
+            [127.10116, 37.48825],
+            [127.10221, 37.48852]
+          ]
+        }
+    """,
+        requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+    )
+    val geom: GeoJson?,
+    @field:Schema(
+        description = "최근 방문 횟수",
+        example = "12",
+        requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+    )
+    val recentlyVisitedCount: Long?,
+)

--- a/pida-core/core-api/src/test/kotlin/com/pida/presentation/v2/category/response/MapCategoryItemDetailResponseTest.kt
+++ b/pida-core/core-api/src/test/kotlin/com/pida/presentation/v2/category/response/MapCategoryItemDetailResponseTest.kt
@@ -1,0 +1,67 @@
+package com.pida.presentation.v2.category.response
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.pida.blooming.BloomingDetails
+import com.pida.blooming.BloomingStatus
+import com.pida.blooming.BloomingStatusDetails
+import com.pida.category.CategoryLabel
+import com.pida.category.MapCategoryItem
+import com.pida.category.MapCategoryItemDetail
+import com.pida.support.geo.GeoJson
+import com.pida.support.geo.Region
+import io.kotest.matchers.string.shouldContain
+import org.junit.jupiter.api.Test
+
+class MapCategoryItemDetailResponseTest {
+    @Test
+    fun `상세 응답은 geom과 bloomingDetails를 함께 직렬화한다`() {
+        val response =
+            MapCategoryItemDetailResponse.from(
+                MapCategoryItemDetail(
+                    categoryId = 3L,
+                    categoryLabel = CategoryLabel.FLOWER_SPOT,
+                    item =
+                        MapCategoryItem(
+                            id = 30L,
+                            name = "밤고개1길",
+                            address = "서울특별시 강남구 수서동",
+                            description = "벚꽃이 예쁜 길",
+                            geom =
+                                GeoJson.LineString(
+                                    listOf(
+                                        listOf(127.10079, 37.48809),
+                                        listOf(127.10116, 37.48825),
+                                    ),
+                                ),
+                            pinPoint = GeoJson.Point(listOf(127.10317, 37.48881)),
+                            region = Region.SEOUL,
+                            recentlyVisitedCount = 2L,
+                            bloomingStatus = BloomingStatus.BLOOMED,
+                        ),
+                    bloomingDetails =
+                        BloomingDetails(
+                            totalCount = 2L,
+                            nickname = "피다",
+                            updatedAt = null,
+                            details =
+                                mapOf(
+                                    "2026-03-19" to
+                                        mapOf(
+                                            "BLOOMED" to BloomingStatusDetails(peopleCount = 2, percentage = 100),
+                                        ),
+                                ),
+                        ),
+                ),
+            )
+
+        val json = jacksonObjectMapper().writeValueAsString(response)
+
+        json shouldContain "\"categoryLabel\":\"FLOWER_SPOT\""
+        json shouldContain "\"common\""
+        json shouldContain "\"detail\""
+        json shouldContain "\"flowerSpot\""
+        json shouldContain "\"geom\""
+        json shouldContain "\"bloomingDetails\""
+        json shouldContain "\"bloomingStatus\":\"BLOOMED\""
+    }
+}

--- a/pida-core/core-api/src/test/kotlin/com/pida/presentation/v2/category/response/MapCategoryItemResponseTest.kt
+++ b/pida-core/core-api/src/test/kotlin/com/pida/presentation/v2/category/response/MapCategoryItemResponseTest.kt
@@ -19,6 +19,7 @@ class MapCategoryItemResponseTest {
                     name = "벚꽃뷰 카페",
                     address = "서울특별시 송파구 석촌호수로 12",
                     description = "석촌호수 근처 카페",
+                    thumbnailUrl = "https://cdn.example.com/cafe-thumbnail.jpg",
                     pinPoint = GeoJson.Point(listOf(127.1040, 37.5070)),
                     region = Region.SEOUL,
                     homepageUrl = null,
@@ -26,6 +27,7 @@ class MapCategoryItemResponseTest {
                     startDate = null,
                     endDate = null,
                     flowerSpotId = 3L,
+                    recentlyVisitedCount = 7L,
                 ),
             )
 
@@ -33,7 +35,10 @@ class MapCategoryItemResponseTest {
 
         json shouldContain "\"mapUrl\""
         json shouldContain "\"flowerSpotId\""
+        json shouldContain "\"thumbnailUrl\""
+        json shouldContain "\"recentlyVisitedCount\":7"
         json shouldNotContain "\"homepageUrl\""
+        json shouldNotContain "\"geom\""
         json shouldNotContain "\"startDate\""
         json shouldNotContain "\"endDate\""
         json shouldNotContain "\"bloomingStatus\""
@@ -48,6 +53,7 @@ class MapCategoryItemResponseTest {
                     name = "여의도 봄꽃축제",
                     address = "서울특별시 영등포구 여의서로 330",
                     description = null,
+                    thumbnailUrl = "https://cdn.example.com/event-thumbnail.jpg",
                     pinPoint = GeoJson.Point(listOf(126.9340, 37.5284)),
                     region = Region.SEOUL,
                     homepageUrl = "https://example.com/festival",
@@ -58,5 +64,6 @@ class MapCategoryItemResponseTest {
         val json = jacksonObjectMapper().writeValueAsString(response)
 
         json shouldContain "\"bloomingStatus\":\"BLOOMED\""
+        json shouldContain "\"thumbnailUrl\""
     }
 }

--- a/pida-core/core-domain/src/main/kotlin/com/pida/category/CafeCategoryItemDetailReadStrategy.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/category/CafeCategoryItemDetailReadStrategy.kt
@@ -1,0 +1,41 @@
+package com.pida.category
+
+import com.pida.blooming.BloomingFacade
+import com.pida.flowerspot.FlowerSpotCafeFinder
+import org.springframework.stereotype.Component
+
+@Component
+class CafeCategoryItemDetailReadStrategy(
+    private val flowerSpotCafeFinder: FlowerSpotCafeFinder,
+    private val bloomingFacade: BloomingFacade,
+) : MapCategoryItemDetailReadStrategy {
+    override val categoryLabel: CategoryLabel = CategoryLabel.CAFE
+
+    override suspend fun read(
+        categoryId: Long,
+        itemId: Long,
+    ): MapCategoryItemDetail {
+        val cafe = flowerSpotCafeFinder.readBy(itemId)
+        val bloomingDetails = bloomingFacade.readBloomingDetails(flowerSpotId = cafe.flowerSpotId)
+
+        return MapCategoryItemDetail(
+            categoryId = categoryId,
+            categoryLabel = categoryLabel,
+            item =
+                MapCategoryItem(
+                    id = cafe.id,
+                    name = cafe.name,
+                    address = cafe.address,
+                    description = cafe.description,
+                    thumbnailUrl = cafe.thumbnailUrl,
+                    pinPoint = cafe.pinPoint,
+                    region = cafe.region,
+                    mapUrl = cafe.mapUrl,
+                    flowerSpotId = cafe.flowerSpotId,
+                    recentlyVisitedCount = bloomingDetails.totalCount,
+                    bloomingStatus = bloomingDetails.representativeBloomingStatus(),
+                ),
+            bloomingDetails = bloomingDetails,
+        )
+    }
+}

--- a/pida-core/core-domain/src/main/kotlin/com/pida/category/CategoryLabel.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/category/CategoryLabel.kt
@@ -5,4 +5,5 @@ enum class CategoryLabel(
 ) {
     EVENT("벚꽃 축제"),
     CAFE("카페"),
+    FLOWER_SPOT("산책길"),
 }

--- a/pida-core/core-domain/src/main/kotlin/com/pida/category/EventCategoryItemDetailReadStrategy.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/category/EventCategoryItemDetailReadStrategy.kt
@@ -1,0 +1,47 @@
+package com.pida.category
+
+import com.pida.blooming.BloomingFacade
+import com.pida.flowerevent.FlowerEventFinder
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import org.springframework.stereotype.Component
+
+@Component
+class EventCategoryItemDetailReadStrategy(
+    private val flowerEventFinder: FlowerEventFinder,
+    private val bloomingFacade: BloomingFacade,
+) : MapCategoryItemDetailReadStrategy {
+    override val categoryLabel: CategoryLabel = CategoryLabel.EVENT
+
+    override suspend fun read(
+        categoryId: Long,
+        itemId: Long,
+    ): MapCategoryItemDetail =
+        coroutineScope {
+            val eventDeferred = async { flowerEventFinder.readBy(itemId) }
+            val bloomingDetailsDeferred = async { bloomingFacade.readBloomingDetails(flowerEventId = itemId) }
+
+            val event = eventDeferred.await()
+            val bloomingDetails = bloomingDetailsDeferred.await()
+
+            MapCategoryItemDetail(
+                categoryId = categoryId,
+                categoryLabel = categoryLabel,
+                item =
+                    MapCategoryItem(
+                        id = event.id,
+                        name = event.name,
+                        address = event.address,
+                        description = null,
+                        thumbnailUrl = event.thumbnailUrl,
+                        pinPoint = event.pinPoint,
+                        region = event.region,
+                        homepageUrl = event.homepageUrl,
+                        startDate = event.startDate,
+                        endDate = event.endDate,
+                        bloomingStatus = bloomingDetails.representativeBloomingStatus(),
+                    ),
+                bloomingDetails = bloomingDetails,
+            )
+        }
+}

--- a/pida-core/core-domain/src/main/kotlin/com/pida/category/EventCategoryItemReadStrategy.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/category/EventCategoryItemReadStrategy.kt
@@ -35,6 +35,7 @@ class EventCategoryItemReadStrategy(
                 name = event.name,
                 address = event.address,
                 description = null,
+                thumbnailUrl = event.thumbnailUrl,
                 pinPoint = event.pinPoint,
                 region = event.region,
                 homepageUrl = event.homepageUrl,

--- a/pida-core/core-domain/src/main/kotlin/com/pida/category/FlowerSpotCategoryItemDetailReadStrategy.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/category/FlowerSpotCategoryItemDetailReadStrategy.kt
@@ -1,0 +1,45 @@
+package com.pida.category
+
+import com.pida.blooming.BloomingFacade
+import com.pida.flowerspot.FlowerSpotService
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import org.springframework.stereotype.Component
+
+@Component
+class FlowerSpotCategoryItemDetailReadStrategy(
+    private val flowerSpotService: FlowerSpotService,
+    private val bloomingFacade: BloomingFacade,
+) : MapCategoryItemDetailReadStrategy {
+    override val categoryLabel: CategoryLabel = CategoryLabel.FLOWER_SPOT
+
+    override suspend fun read(
+        categoryId: Long,
+        itemId: Long,
+    ): MapCategoryItemDetail =
+        coroutineScope {
+            val flowerSpotDeferred = async { flowerSpotService.readOneFlowerSpot(itemId) }
+            val bloomingDetailsDeferred = async { bloomingFacade.readBloomingDetails(flowerSpotId = itemId) }
+
+            val flowerSpot = flowerSpotDeferred.await()
+            val bloomingDetails = bloomingDetailsDeferred.await()
+
+            MapCategoryItemDetail(
+                categoryId = categoryId,
+                categoryLabel = categoryLabel,
+                item =
+                    MapCategoryItem(
+                        id = flowerSpot.id,
+                        name = flowerSpot.streetName,
+                        address = flowerSpot.address,
+                        description = flowerSpot.description,
+                        geom = flowerSpot.geom,
+                        pinPoint = flowerSpot.pinPoint,
+                        region = flowerSpot.region,
+                        recentlyVisitedCount = bloomingDetails.totalCount,
+                        bloomingStatus = bloomingDetails.representativeBloomingStatus(),
+                    ),
+                bloomingDetails = bloomingDetails,
+            )
+        }
+}

--- a/pida-core/core-domain/src/main/kotlin/com/pida/category/FlowerSpotCategoryItemReadStrategy.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/category/FlowerSpotCategoryItemReadStrategy.kt
@@ -2,18 +2,17 @@ package com.pida.category
 
 import com.pida.blooming.BloomingService
 import com.pida.blooming.BloomingStatus
-import com.pida.flowerspot.FlowerSpotCafeFinder
 import com.pida.flowerspot.FlowerSpotLocation
-import com.pida.flowerspot.hasBounds
+import com.pida.flowerspot.FlowerSpotService
 import org.springframework.stereotype.Component
 
 @Component
-class CafeCategoryItemReadStrategy(
+class FlowerSpotCategoryItemReadStrategy(
     private val mapCategoryService: MapCategoryService,
-    private val flowerSpotCafeFinder: FlowerSpotCafeFinder,
+    private val flowerSpotService: FlowerSpotService,
     private val bloomingService: BloomingService,
 ) : MapCategoryItemReadStrategy {
-    override val categoryLabel: CategoryLabel = CategoryLabel.CAFE
+    override val categoryLabel: CategoryLabel = CategoryLabel.FLOWER_SPOT
 
     override suspend fun read(
         categoryId: Long,
@@ -21,29 +20,23 @@ class CafeCategoryItemReadStrategy(
     ): List<MapCategoryItem> {
         validateCategoryId(categoryId)
 
-        val cafes =
-            if (location.hasBounds()) {
-                flowerSpotCafeFinder.readAllByLocation(location)
-            } else {
-                flowerSpotCafeFinder.readAll()
-            }
+        val flowerSpots = flowerSpotService.readAllFlowerSpot(region = null, location = location)
         val recentBloomingBySpotId =
             bloomingService
-                .recentlyBloomingBySpotIds(cafes.map { it.flowerSpotId })
+                .recentlyBloomingBySpotIds(flowerSpots.map { it.id })
                 .groupBy { it.flowerSpotId }
 
-        return cafes.map { cafe ->
-            val recentBloomings = recentBloomingBySpotId[cafe.flowerSpotId] ?: emptyList()
+        return flowerSpots.map { flowerSpot ->
+            val recentBloomings = recentBloomingBySpotId[flowerSpot.id] ?: emptyList()
+
             MapCategoryItem(
-                id = cafe.id,
-                name = cafe.name,
-                address = cafe.address,
-                description = cafe.description,
-                thumbnailUrl = cafe.thumbnailUrl,
-                pinPoint = cafe.pinPoint,
-                region = cafe.region,
-                mapUrl = cafe.mapUrl,
-                flowerSpotId = cafe.flowerSpotId,
+                id = flowerSpot.id,
+                name = flowerSpot.streetName,
+                address = flowerSpot.address,
+                description = flowerSpot.description,
+                geom = flowerSpot.geom,
+                pinPoint = flowerSpot.pinPoint,
+                region = flowerSpot.region,
                 recentlyVisitedCount = recentBloomings.size.toLong(),
                 bloomingStatus =
                     recentBloomings
@@ -56,7 +49,7 @@ class CafeCategoryItemReadStrategy(
 
     private suspend fun validateCategoryId(categoryId: Long) {
         check(mapCategoryService.findAllByCategoryLabel(categoryLabel).singleOrNull()?.id == categoryId) {
-            "CAFE category must be uniquely mapped to one active category."
+            "FLOWER_SPOT category must be uniquely mapped to one active category."
         }
     }
 }

--- a/pida-core/core-domain/src/main/kotlin/com/pida/category/MapCategoryBloomingStatus.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/category/MapCategoryBloomingStatus.kt
@@ -1,0 +1,17 @@
+package com.pida.category
+
+import com.pida.blooming.BloomingDetails
+import com.pida.blooming.BloomingStatus
+
+fun BloomingDetails.representativeBloomingStatus(): BloomingStatus =
+    details.values
+        .flatMap { dailyDetails ->
+            dailyDetails.map { (statusName, statusDetails) ->
+                BloomingStatus.valueOf(statusName) to statusDetails.peopleCount
+            }
+        }.groupBy(
+            keySelector = { it.first },
+            valueTransform = { it.second },
+        ).maxByOrNull { (_, counts) -> counts.sum() }
+        ?.key
+        ?: BloomingStatus.NOT_BLOOMED

--- a/pida-core/core-domain/src/main/kotlin/com/pida/category/MapCategoryFacade.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/category/MapCategoryFacade.kt
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service
 class MapCategoryFacade(
     private val mapCategoryService: MapCategoryService,
     categoryItemReadStrategies: List<MapCategoryItemReadStrategy>,
+    categoryItemDetailReadStrategies: List<MapCategoryItemDetailReadStrategy>,
 ) {
     /**
      * 카테고리 ID로 카테고리를 조회한 뒤,
@@ -18,10 +19,15 @@ class MapCategoryFacade(
      */
     private val strategiesByCategory =
         categoryItemReadStrategies.associateBy(MapCategoryItemReadStrategy::categoryLabel)
+    private val detailStrategiesByCategory =
+        categoryItemDetailReadStrategies.associateBy(MapCategoryItemDetailReadStrategy::categoryLabel)
 
     init {
         require(categoryItemReadStrategies.size == strategiesByCategory.size) {
             "Map category item strategy must be unique by category label."
+        }
+        require(categoryItemDetailReadStrategies.size == detailStrategiesByCategory.size) {
+            "Map category item detail strategy must be unique by category label."
         }
     }
 
@@ -40,5 +46,18 @@ class MapCategoryFacade(
             categoryLabel = category.categoryLabel,
             list = strategy.read(category.id, location),
         )
+    }
+
+    suspend fun readDetailByCategoryId(
+        categoryId: Long,
+        itemId: Long,
+    ): MapCategoryItemDetail {
+        val category = mapCategoryService.readBy(categoryId)
+        val strategy =
+            requireNotNull(detailStrategiesByCategory[category.categoryLabel]) {
+                "No map category item detail strategy for ${category.categoryLabel}"
+            }
+
+        return strategy.read(category.id, itemId)
     }
 }

--- a/pida-core/core-domain/src/main/kotlin/com/pida/category/MapCategoryItem.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/category/MapCategoryItem.kt
@@ -1,5 +1,6 @@
 package com.pida.category
 
+import com.pida.blooming.BloomingDetails
 import com.pida.blooming.BloomingStatus
 import com.pida.support.geo.GeoJson
 import com.pida.support.geo.Region
@@ -16,6 +17,8 @@ data class MapCategoryItem(
     val name: String,
     val address: String?,
     val description: String?,
+    val thumbnailUrl: String? = null,
+    val geom: GeoJson? = null,
     val pinPoint: GeoJson,
     val region: Region,
     val homepageUrl: String? = null,
@@ -23,5 +26,13 @@ data class MapCategoryItem(
     val startDate: LocalDate? = null,
     val endDate: LocalDate? = null,
     val flowerSpotId: Long? = null,
+    val recentlyVisitedCount: Long? = null,
     val bloomingStatus: BloomingStatus? = null,
+)
+
+data class MapCategoryItemDetail(
+    val categoryId: Long,
+    val categoryLabel: CategoryLabel,
+    val item: MapCategoryItem,
+    val bloomingDetails: BloomingDetails,
 )

--- a/pida-core/core-domain/src/main/kotlin/com/pida/category/MapCategoryItemDetailReadStrategy.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/category/MapCategoryItemDetailReadStrategy.kt
@@ -1,0 +1,10 @@
+package com.pida.category
+
+interface MapCategoryItemDetailReadStrategy {
+    val categoryLabel: CategoryLabel
+
+    suspend fun read(
+        categoryId: Long,
+        itemId: Long,
+    ): MapCategoryItemDetail
+}

--- a/pida-core/core-domain/src/main/kotlin/com/pida/flowerevent/FlowerEvent.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/flowerevent/FlowerEvent.kt
@@ -9,6 +9,7 @@ data class FlowerEvent(
     val id: Long,
     val name: String,
     val address: String?,
+    val thumbnailUrl: String? = null,
     val pinPoint: GeoJson,
     val region: Region,
     val homepageUrl: String?,

--- a/pida-core/core-domain/src/main/kotlin/com/pida/flowerspot/FlowerSpotCafe.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/flowerspot/FlowerSpotCafe.kt
@@ -10,6 +10,7 @@ data class FlowerSpotCafe(
     val name: String,
     val address: String?,
     val description: String?,
+    val thumbnailUrl: String? = null,
     val pinPoint: GeoJson,
     val region: Region,
     val mapUrl: String?,

--- a/pida-core/core-domain/src/test/kotlin/com/pida/blooming/BloomingFacadeTest.kt
+++ b/pida-core/core-domain/src/test/kotlin/com/pida/blooming/BloomingFacadeTest.kt
@@ -4,8 +4,8 @@ import com.pida.reporter.RecentReporterService
 import com.pida.support.aws.ImagePrefix
 import com.pida.support.aws.ImageS3Caller
 import com.pida.support.aws.S3ImageUrl
-import com.pida.user.UserService
 import com.pida.user.UserProfile
+import com.pida.user.UserService
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.every

--- a/pida-core/core-domain/src/test/kotlin/com/pida/category/CafeCategoryItemDetailReadStrategyTest.kt
+++ b/pida-core/core-domain/src/test/kotlin/com/pida/category/CafeCategoryItemDetailReadStrategyTest.kt
@@ -1,0 +1,63 @@
+package com.pida.category
+
+import com.pida.blooming.BloomingDetails
+import com.pida.blooming.BloomingFacade
+import com.pida.blooming.BloomingStatus
+import com.pida.blooming.BloomingStatusDetails
+import com.pida.flowerspot.FlowerSpotCafe
+import com.pida.flowerspot.FlowerSpotCafeFinder
+import com.pida.support.geo.GeoJson
+import com.pida.support.geo.Region
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+
+class CafeCategoryItemDetailReadStrategyTest {
+    @Test
+    fun `카페 상세는 연결된 벚꽃길의 개화 상세를 함께 응답한다`(): Unit =
+        runBlocking {
+            val flowerSpotCafeFinder = mockk<FlowerSpotCafeFinder>()
+            val bloomingFacade = mockk<BloomingFacade>()
+            val strategy = CafeCategoryItemDetailReadStrategy(flowerSpotCafeFinder, bloomingFacade)
+
+            coEvery { flowerSpotCafeFinder.readBy(20L) } returns
+                FlowerSpotCafe(
+                    id = 20L,
+                    flowerSpotId = 3L,
+                    name = "벚꽃뷰 카페",
+                    address = "서울특별시 송파구 석촌호수로 12",
+                    description = "석촌호수 근처 카페",
+                    thumbnailUrl = "https://cdn.example.com/cafe-thumbnail.jpg",
+                    pinPoint = GeoJson.Point(listOf(127.1040, 37.5070)),
+                    region = Region.SEOUL,
+                    mapUrl = "https://place.map.kakao.com/123456",
+                    deletedAt = null,
+                )
+            coEvery { bloomingFacade.readBloomingDetails(flowerSpotId = 3L) } returns
+                BloomingDetails(
+                    totalCount = 5L,
+                    nickname = "피다",
+                    updatedAt = LocalDateTime.of(2026, 3, 19, 10, 0),
+                    details =
+                        mapOf(
+                            "2026-03-19" to
+                                mapOf(
+                                    "BLOOMED" to BloomingStatusDetails(peopleCount = 3, percentage = 60),
+                                    "LITTLE" to BloomingStatusDetails(peopleCount = 2, percentage = 40),
+                                ),
+                        ),
+                )
+
+            val result = strategy.read(categoryId = 2L, itemId = 20L)
+
+            result.categoryId shouldBe 2L
+            result.categoryLabel shouldBe CategoryLabel.CAFE
+            result.item.flowerSpotId shouldBe 3L
+            result.item.thumbnailUrl shouldBe "https://cdn.example.com/cafe-thumbnail.jpg"
+            result.item.recentlyVisitedCount shouldBe 5L
+            result.item.bloomingStatus shouldBe BloomingStatus.BLOOMED
+        }
+}

--- a/pida-core/core-domain/src/test/kotlin/com/pida/category/CafeCategoryItemReadStrategyTest.kt
+++ b/pida-core/core-domain/src/test/kotlin/com/pida/category/CafeCategoryItemReadStrategyTest.kt
@@ -144,9 +144,10 @@ class CafeCategoryItemReadStrategyTest {
                 )
 
             val exception =
-                kotlin.runCatching {
-                    strategy.read(2L, location)
-                }.exceptionOrNull()
+                kotlin
+                    .runCatching {
+                        strategy.read(2L, location)
+                    }.exceptionOrNull()
 
             exception.shouldBeInstanceOf<IllegalStateException>()
             exception.message shouldBe "CAFE category must be uniquely mapped to one active category."

--- a/pida-core/core-domain/src/test/kotlin/com/pida/category/CafeCategoryItemReadStrategyTest.kt
+++ b/pida-core/core-domain/src/test/kotlin/com/pida/category/CafeCategoryItemReadStrategyTest.kt
@@ -1,5 +1,8 @@
 package com.pida.category
 
+import com.pida.blooming.Blooming
+import com.pida.blooming.BloomingService
+import com.pida.blooming.BloomingStatus
 import com.pida.flowerspot.FlowerSpotCafe
 import com.pida.flowerspot.FlowerSpotCafeFinder
 import com.pida.flowerspot.FlowerSpotLocation
@@ -9,6 +12,7 @@ import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.mockk.coEvery
+import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Test
@@ -19,7 +23,8 @@ class CafeCategoryItemReadStrategyTest {
         runBlocking {
             val mapCategoryService = mockk<MapCategoryService>()
             val flowerSpotCafeFinder = mockk<FlowerSpotCafeFinder>()
-            val strategy = CafeCategoryItemReadStrategy(mapCategoryService, flowerSpotCafeFinder)
+            val bloomingService = mockk<BloomingService>()
+            val strategy = CafeCategoryItemReadStrategy(mapCategoryService, flowerSpotCafeFinder, bloomingService)
             val location = FlowerSpotLocation(swLat = null, swLng = null, neLat = null, neLng = null)
             val category =
                 MapCategory(
@@ -36,6 +41,7 @@ class CafeCategoryItemReadStrategyTest {
                     name = "벚꽃뷰 카페",
                     address = "서울특별시 송파구 석촌호수로 12",
                     description = "석촌호수 근처 카페",
+                    thumbnailUrl = "https://cdn.example.com/cafe-thumbnail.jpg",
                     pinPoint = GeoJson.Point(listOf(127.1040, 37.5070)),
                     region = Region.SEOUL,
                     mapUrl = "https://place.map.kakao.com/123456",
@@ -44,12 +50,26 @@ class CafeCategoryItemReadStrategyTest {
 
             coEvery { mapCategoryService.findAllByCategoryLabel(CategoryLabel.CAFE) } returns listOf(category)
             coEvery { flowerSpotCafeFinder.readAll() } returns listOf(cafe)
+            every { bloomingService.recentlyBloomingBySpotIds(listOf(3L)) } returns
+                listOf(
+                    Blooming(
+                        id = 1L,
+                        status = BloomingStatus.BLOOMED,
+                        userId = 1L,
+                        flowerSpotId = 3L,
+                        flowerEventId = null,
+                        createdAt = java.time.LocalDateTime.of(2026, 3, 19, 10, 0),
+                    ),
+                )
 
             val result = strategy.read(2L, location)
 
             result shouldHaveSize 1
             result.first().id shouldBe 20L
             result.first().flowerSpotId shouldBe 3L
+            result.first().thumbnailUrl shouldBe "https://cdn.example.com/cafe-thumbnail.jpg"
+            result.first().recentlyVisitedCount shouldBe 1L
+            result.first().bloomingStatus shouldBe BloomingStatus.BLOOMED
         }
 
     @Test
@@ -57,7 +77,8 @@ class CafeCategoryItemReadStrategyTest {
         runBlocking {
             val mapCategoryService = mockk<MapCategoryService>()
             val flowerSpotCafeFinder = mockk<FlowerSpotCafeFinder>()
-            val strategy = CafeCategoryItemReadStrategy(mapCategoryService, flowerSpotCafeFinder)
+            val bloomingService = mockk<BloomingService>()
+            val strategy = CafeCategoryItemReadStrategy(mapCategoryService, flowerSpotCafeFinder, bloomingService)
             val location = FlowerSpotLocation(swLat = 37.4, swLng = 126.8, neLat = 37.6, neLng = 127.1)
             val category =
                 MapCategory(
@@ -74,6 +95,7 @@ class CafeCategoryItemReadStrategyTest {
                     name = "호수뷰 카페",
                     address = "서울특별시 송파구 잠실동",
                     description = "호수 근처 카페",
+                    thumbnailUrl = null,
                     pinPoint = GeoJson.Point(listOf(127.1050, 37.5080)),
                     region = Region.SEOUL,
                     mapUrl = "https://place.map.kakao.com/654321",
@@ -82,12 +104,14 @@ class CafeCategoryItemReadStrategyTest {
 
             coEvery { mapCategoryService.findAllByCategoryLabel(CategoryLabel.CAFE) } returns listOf(category)
             coEvery { flowerSpotCafeFinder.readAllByLocation(location) } returns listOf(cafe)
+            every { bloomingService.recentlyBloomingBySpotIds(listOf(4L)) } returns emptyList<Blooming>()
 
             val result = strategy.read(2L, location)
 
             result shouldHaveSize 1
             result.first().id shouldBe 21L
             result.first().mapUrl shouldBe "https://place.map.kakao.com/654321"
+            result.first().bloomingStatus shouldBe BloomingStatus.NOT_BLOOMED
         }
 
     @Test
@@ -95,7 +119,8 @@ class CafeCategoryItemReadStrategyTest {
         runBlocking {
             val mapCategoryService = mockk<MapCategoryService>()
             val flowerSpotCafeFinder = mockk<FlowerSpotCafeFinder>()
-            val strategy = CafeCategoryItemReadStrategy(mapCategoryService, flowerSpotCafeFinder)
+            val bloomingService = mockk<BloomingService>()
+            val strategy = CafeCategoryItemReadStrategy(mapCategoryService, flowerSpotCafeFinder, bloomingService)
             val location = FlowerSpotLocation(swLat = null, swLng = null, neLat = null, neLng = null)
 
             coEvery {

--- a/pida-core/core-domain/src/test/kotlin/com/pida/category/EventCategoryItemDetailReadStrategyTest.kt
+++ b/pida-core/core-domain/src/test/kotlin/com/pida/category/EventCategoryItemDetailReadStrategyTest.kt
@@ -1,0 +1,66 @@
+package com.pida.category
+
+import com.pida.blooming.BloomingDetails
+import com.pida.blooming.BloomingFacade
+import com.pida.blooming.BloomingStatusDetails
+import com.pida.flowerevent.FlowerEvent
+import com.pida.flowerevent.FlowerEventFinder
+import com.pida.support.geo.GeoJson
+import com.pida.support.geo.Region
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+class EventCategoryItemDetailReadStrategyTest {
+    @Test
+    fun `이벤트 상세는 썸네일과 개화 상세를 함께 응답한다`(): Unit =
+        runBlocking {
+            val flowerEventFinder = mockk<FlowerEventFinder>()
+            val bloomingFacade = mockk<BloomingFacade>()
+            val strategy = EventCategoryItemDetailReadStrategy(flowerEventFinder, bloomingFacade)
+
+            coEvery { flowerEventFinder.readBy(10L) } returns
+                FlowerEvent(
+                    id = 10L,
+                    name = "여의도 봄꽃축제",
+                    address = "서울특별시 영등포구 여의서로 330",
+                    thumbnailUrl = "https://cdn.example.com/event-thumbnail.jpg",
+                    pinPoint = GeoJson.Point(listOf(126.9340, 37.5284)),
+                    region = Region.SEOUL,
+                    homepageUrl = "https://example.com/festival",
+                    startDate = LocalDate.of(2026, 3, 20),
+                    endDate = LocalDate.of(2026, 3, 30),
+                    categoryId = 1L,
+                    deletedAt = null,
+                )
+            coEvery { bloomingFacade.readBloomingDetails(flowerEventId = 10L) } returns
+                BloomingDetails(
+                    totalCount = 3L,
+                    nickname = "봄길러",
+                    updatedAt = LocalDateTime.of(2026, 3, 19, 11, 0),
+                    details =
+                        mapOf(
+                            "2026-03-19" to
+                                mapOf(
+                                    "BLOOMED" to BloomingStatusDetails(peopleCount = 2, percentage = 100),
+                                ),
+                            "2026-03-18" to
+                                mapOf(
+                                    "LITTLE" to BloomingStatusDetails(peopleCount = 1, percentage = 100),
+                                ),
+                        ),
+                )
+
+            val result = strategy.read(categoryId = 1L, itemId = 10L)
+
+            result.categoryId shouldBe 1L
+            result.categoryLabel shouldBe CategoryLabel.EVENT
+            result.item.thumbnailUrl shouldBe "https://cdn.example.com/event-thumbnail.jpg"
+            result.item.bloomingStatus shouldBe com.pida.blooming.BloomingStatus.BLOOMED
+            result.bloomingDetails.totalCount shouldBe 3L
+        }
+}

--- a/pida-core/core-domain/src/test/kotlin/com/pida/category/EventCategoryItemReadStrategyTest.kt
+++ b/pida-core/core-domain/src/test/kotlin/com/pida/category/EventCategoryItemReadStrategyTest.kt
@@ -30,6 +30,7 @@ class EventCategoryItemReadStrategyTest {
                     id = 10L,
                     name = "여의도 봄꽃축제",
                     address = "서울특별시 영등포구 여의서로 330",
+                    thumbnailUrl = "https://cdn.example.com/event-thumbnail.jpg",
                     pinPoint = GeoJson.Point(listOf(126.9340, 37.5284)),
                     region = Region.SEOUL,
                     homepageUrl = "https://example.com/festival",
@@ -57,6 +58,7 @@ class EventCategoryItemReadStrategyTest {
             result shouldHaveSize 1
             result.first().id shouldBe 10L
             result.first().homepageUrl shouldBe "https://example.com/festival"
+            result.first().thumbnailUrl shouldBe "https://cdn.example.com/event-thumbnail.jpg"
             result.first().bloomingStatus shouldBe BloomingStatus.BLOOMED
         }
 
@@ -72,6 +74,7 @@ class EventCategoryItemReadStrategyTest {
                     id = 11L,
                     name = "석촌호수 벚꽃축제",
                     address = "서울특별시 송파구 잠실동",
+                    thumbnailUrl = null,
                     pinPoint = GeoJson.Point(listOf(127.1040, 37.5070)),
                     region = Region.SEOUL,
                     homepageUrl = "https://example.com/lake-festival",

--- a/pida-core/core-domain/src/test/kotlin/com/pida/category/FlowerSpotCategoryItemDetailReadStrategyTest.kt
+++ b/pida-core/core-domain/src/test/kotlin/com/pida/category/FlowerSpotCategoryItemDetailReadStrategyTest.kt
@@ -1,0 +1,72 @@
+package com.pida.category
+
+import com.pida.blooming.BloomingDetails
+import com.pida.blooming.BloomingFacade
+import com.pida.blooming.BloomingStatus
+import com.pida.blooming.BloomingStatusDetails
+import com.pida.flowerspot.FlowerKind
+import com.pida.flowerspot.FlowerSpot
+import com.pida.flowerspot.FlowerSpotService
+import com.pida.flowerspot.FlowerSpotType
+import com.pida.support.geo.GeoJson
+import com.pida.support.geo.Region
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+
+class FlowerSpotCategoryItemDetailReadStrategyTest {
+    @Test
+    fun `산책길 상세는 LineString과 blooming details를 응답한다`(): Unit =
+        runBlocking {
+            val flowerSpotService = mockk<FlowerSpotService>()
+            val bloomingFacade = mockk<BloomingFacade>()
+            val strategy = FlowerSpotCategoryItemDetailReadStrategy(flowerSpotService, bloomingFacade)
+            val geom =
+                GeoJson.LineString(
+                    listOf(
+                        listOf(127.10079, 37.48809),
+                        listOf(127.10116, 37.48825),
+                    ),
+                )
+
+            coEvery { flowerSpotService.readOneFlowerSpot(30L) } returns
+                FlowerSpot(
+                    id = 30L,
+                    address = "서울특별시 강남구 수서동",
+                    streetName = "밤고개1길",
+                    district = "수서동",
+                    description = "벚꽃이 예쁜 길",
+                    geom = geom,
+                    pinPoint = GeoJson.Point(listOf(127.10317, 37.48881)),
+                    region = Region.SEOUL,
+                    kind = FlowerKind.BLOSSOM,
+                    type = FlowerSpotType.WALKING_TRAIL,
+                    deletedAt = null,
+                )
+            coEvery { bloomingFacade.readBloomingDetails(flowerSpotId = 30L) } returns
+                BloomingDetails(
+                    totalCount = 2L,
+                    nickname = "피다",
+                    updatedAt = LocalDateTime.of(2026, 3, 19, 10, 0),
+                    details =
+                        mapOf(
+                            "2026-03-19" to
+                                mapOf(
+                                    "BLOOMED" to BloomingStatusDetails(peopleCount = 2, percentage = 100),
+                                ),
+                        ),
+                )
+
+            val result = strategy.read(categoryId = 3L, itemId = 30L)
+
+            result.categoryId shouldBe 3L
+            result.categoryLabel shouldBe CategoryLabel.FLOWER_SPOT
+            result.item.name shouldBe "밤고개1길"
+            result.item.geom shouldBe geom
+            result.item.recentlyVisitedCount shouldBe 2L
+            result.item.bloomingStatus shouldBe BloomingStatus.BLOOMED
+        }
+}

--- a/pida-core/core-domain/src/test/kotlin/com/pida/category/FlowerSpotCategoryItemReadStrategyTest.kt
+++ b/pida-core/core-domain/src/test/kotlin/com/pida/category/FlowerSpotCategoryItemReadStrategyTest.kt
@@ -1,0 +1,82 @@
+package com.pida.category
+
+import com.pida.blooming.Blooming
+import com.pida.blooming.BloomingService
+import com.pida.blooming.BloomingStatus
+import com.pida.flowerspot.FlowerKind
+import com.pida.flowerspot.FlowerSpot
+import com.pida.flowerspot.FlowerSpotLocation
+import com.pida.flowerspot.FlowerSpotService
+import com.pida.flowerspot.FlowerSpotType
+import com.pida.support.geo.GeoJson
+import com.pida.support.geo.Region
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+
+class FlowerSpotCategoryItemReadStrategyTest {
+    @Test
+    fun `산책길 카테고리는 flower spot의 LineString과 개화 요약을 응답한다`(): Unit =
+        runBlocking {
+            val mapCategoryService = mockk<MapCategoryService>()
+            val flowerSpotService = mockk<FlowerSpotService>()
+            val bloomingService = mockk<BloomingService>()
+            val strategy = FlowerSpotCategoryItemReadStrategy(mapCategoryService, flowerSpotService, bloomingService)
+            val location = FlowerSpotLocation(swLat = null, swLng = null, neLat = null, neLng = null)
+            val category =
+                MapCategory(
+                    id = 3L,
+                    title = "산책길",
+                    categoryLabel = CategoryLabel.FLOWER_SPOT,
+                    description = "산책길 카테고리",
+                    deletedAt = null,
+                )
+            val flowerSpot =
+                FlowerSpot(
+                    id = 30L,
+                    address = "서울특별시 강남구 수서동",
+                    streetName = "밤고개1길",
+                    district = "수서동",
+                    description = "벚꽃이 예쁜 길",
+                    geom =
+                        GeoJson.LineString(
+                            listOf(
+                                listOf(127.10079, 37.48809),
+                                listOf(127.10116, 37.48825),
+                            ),
+                        ),
+                    pinPoint = GeoJson.Point(listOf(127.10317, 37.48881)),
+                    region = Region.SEOUL,
+                    kind = FlowerKind.BLOSSOM,
+                    type = FlowerSpotType.WALKING_TRAIL,
+                    deletedAt = null,
+                )
+
+            coEvery { mapCategoryService.findAllByCategoryLabel(CategoryLabel.FLOWER_SPOT) } returns listOf(category)
+            coEvery { flowerSpotService.readAllFlowerSpot(region = null, location = location) } returns listOf(flowerSpot)
+            every { bloomingService.recentlyBloomingBySpotIds(listOf(30L)) } returns
+                listOf(
+                    Blooming(
+                        id = 1L,
+                        status = BloomingStatus.BLOOMED,
+                        userId = 1L,
+                        flowerSpotId = 30L,
+                        flowerEventId = null,
+                        createdAt = LocalDateTime.of(2026, 3, 19, 10, 0),
+                    ),
+                )
+
+            val result = strategy.read(3L, location)
+
+            result shouldHaveSize 1
+            result.first().name shouldBe "밤고개1길"
+            result.first().geom shouldBe flowerSpot.geom
+            result.first().recentlyVisitedCount shouldBe 1L
+            result.first().bloomingStatus shouldBe BloomingStatus.BLOOMED
+        }
+}

--- a/pida-core/core-domain/src/test/kotlin/com/pida/category/MapCategoryFacadeTest.kt
+++ b/pida-core/core-domain/src/test/kotlin/com/pida/category/MapCategoryFacadeTest.kt
@@ -19,11 +19,20 @@ class MapCategoryFacadeTest {
             val mapCategoryService = mockk<MapCategoryService>()
             val eventStrategy = mockk<MapCategoryItemReadStrategy>()
             val cafeStrategy = mockk<MapCategoryItemReadStrategy>()
+            val eventDetailStrategy = mockk<MapCategoryItemDetailReadStrategy>()
+            val cafeDetailStrategy = mockk<MapCategoryItemDetailReadStrategy>()
 
             every { eventStrategy.categoryLabel } returns CategoryLabel.EVENT
             every { cafeStrategy.categoryLabel } returns CategoryLabel.CAFE
+            every { eventDetailStrategy.categoryLabel } returns CategoryLabel.EVENT
+            every { cafeDetailStrategy.categoryLabel } returns CategoryLabel.CAFE
 
-            val facade = MapCategoryFacade(mapCategoryService, listOf(eventStrategy, cafeStrategy))
+            val facade =
+                MapCategoryFacade(
+                    mapCategoryService = mapCategoryService,
+                    categoryItemReadStrategies = listOf(eventStrategy, cafeStrategy),
+                    categoryItemDetailReadStrategies = listOf(eventDetailStrategy, cafeDetailStrategy),
+                )
 
             val category =
                 MapCategory(
@@ -40,6 +49,7 @@ class MapCategoryFacadeTest {
                     name = "여의도 봄꽃축제",
                     address = "서울특별시 영등포구 여의서로 330",
                     description = null,
+                    thumbnailUrl = null,
                     pinPoint = GeoJson.Point(listOf(126.9340, 37.5284)),
                     region = Region.SEOUL,
                     homepageUrl = "https://example.com/festival",
@@ -66,9 +76,11 @@ class MapCategoryFacadeTest {
             val mapCategoryService = mockk<MapCategoryService>()
             val firstEventStrategy = mockk<MapCategoryItemReadStrategy>()
             val secondEventStrategy = mockk<MapCategoryItemReadStrategy>()
+            val eventDetailStrategy = mockk<MapCategoryItemDetailReadStrategy>()
 
             every { firstEventStrategy.categoryLabel } returns CategoryLabel.EVENT
             every { secondEventStrategy.categoryLabel } returns CategoryLabel.EVENT
+            every { eventDetailStrategy.categoryLabel } returns CategoryLabel.EVENT
 
             val exception =
                 kotlin
@@ -76,9 +88,95 @@ class MapCategoryFacadeTest {
                         MapCategoryFacade(
                             mapCategoryService = mapCategoryService,
                             categoryItemReadStrategies = listOf(firstEventStrategy, secondEventStrategy),
+                            categoryItemDetailReadStrategies = listOf(eventDetailStrategy),
                         )
                     }.exceptionOrNull()
 
             exception?.message shouldBe "Map category item strategy must be unique by category label."
+        }
+
+    @Test
+    fun `카테고리 라벨에 맞는 전략으로 상세를 조회한다`(): Unit =
+        runBlocking {
+            val mapCategoryService = mockk<MapCategoryService>()
+            val eventStrategy = mockk<MapCategoryItemReadStrategy>()
+            val cafeStrategy = mockk<MapCategoryItemReadStrategy>()
+            val eventDetailStrategy = mockk<MapCategoryItemDetailReadStrategy>()
+            val cafeDetailStrategy = mockk<MapCategoryItemDetailReadStrategy>()
+
+            every { eventStrategy.categoryLabel } returns CategoryLabel.EVENT
+            every { cafeStrategy.categoryLabel } returns CategoryLabel.CAFE
+            every { eventDetailStrategy.categoryLabel } returns CategoryLabel.EVENT
+            every { cafeDetailStrategy.categoryLabel } returns CategoryLabel.CAFE
+
+            val facade =
+                MapCategoryFacade(
+                    mapCategoryService = mapCategoryService,
+                    categoryItemReadStrategies = listOf(eventStrategy, cafeStrategy),
+                    categoryItemDetailReadStrategies = listOf(eventDetailStrategy, cafeDetailStrategy),
+                )
+
+            val category =
+                MapCategory(
+                    id = 1L,
+                    title = "벚꽃 축제",
+                    categoryLabel = CategoryLabel.EVENT,
+                    description = "벚꽃 축제 카테고리",
+                    deletedAt = null,
+                )
+            val detail =
+                MapCategoryItemDetail(
+                    categoryId = 1L,
+                    categoryLabel = CategoryLabel.EVENT,
+                    item =
+                        MapCategoryItem(
+                            id = 10L,
+                            name = "여의도 봄꽃축제",
+                            address = "서울특별시 영등포구 여의서로 330",
+                            description = null,
+                            pinPoint = GeoJson.Point(listOf(126.9340, 37.5284)),
+                            region = Region.SEOUL,
+                            homepageUrl = "https://example.com/festival",
+                        ),
+                    bloomingDetails =
+                        com.pida.blooming.BloomingDetails(
+                            totalCount = 1L,
+                            nickname = "피다",
+                            updatedAt = null,
+                            details = emptyMap(),
+                        ),
+                )
+
+            coEvery { mapCategoryService.readBy(1L) } returns category
+            coEvery { eventDetailStrategy.read(1L, 10L) } returns detail
+
+            val result = facade.readDetailByCategoryId(1L, 10L)
+
+            result shouldBe detail
+        }
+
+    @Test
+    fun `상세 전략은 카테고리별로 하나만 등록할 수 있다`(): Unit =
+        runBlocking {
+            val mapCategoryService = mockk<MapCategoryService>()
+            val eventStrategy = mockk<MapCategoryItemReadStrategy>()
+            val firstEventDetailStrategy = mockk<MapCategoryItemDetailReadStrategy>()
+            val secondEventDetailStrategy = mockk<MapCategoryItemDetailReadStrategy>()
+
+            every { eventStrategy.categoryLabel } returns CategoryLabel.EVENT
+            every { firstEventDetailStrategy.categoryLabel } returns CategoryLabel.EVENT
+            every { secondEventDetailStrategy.categoryLabel } returns CategoryLabel.EVENT
+
+            val exception =
+                kotlin
+                    .runCatching {
+                        MapCategoryFacade(
+                            mapCategoryService = mapCategoryService,
+                            categoryItemReadStrategies = listOf(eventStrategy),
+                            categoryItemDetailReadStrategies = listOf(firstEventDetailStrategy, secondEventDetailStrategy),
+                        )
+                    }.exceptionOrNull()
+
+            exception?.message shouldBe "Map category item detail strategy must be unique by category label."
         }
 }

--- a/pida-storage/db-core/src/main/kotlin/com/pida/storage/db/core/blooming/BloomingCustomRepository.kt
+++ b/pida-storage/db-core/src/main/kotlin/com/pida/storage/db/core/blooming/BloomingCustomRepository.kt
@@ -196,7 +196,9 @@ class BloomingCustomRepository(
     fun countBloomedVotesByRegionAndCreatedAtAfter(
         region: Region,
         createdAtAfter: LocalDateTime,
-    ): Long = countBloomedSpotVotesByRegionAndCreatedAtAfter(region, createdAtAfter) + countBloomedEventVotesByRegionAndCreatedAtAfter(region, createdAtAfter)
+    ): Long =
+        countBloomedSpotVotesByRegionAndCreatedAtAfter(region, createdAtAfter) +
+            countBloomedEventVotesByRegionAndCreatedAtAfter(region, createdAtAfter)
 
     private fun countSpotByRegionAndStatus(threshold: LocalDateTime): List<RegionStatusCount> {
         val query =

--- a/pida-storage/db-core/src/main/kotlin/com/pida/storage/db/core/flowerevent/FlowerEventEntity.kt
+++ b/pida-storage/db-core/src/main/kotlin/com/pida/storage/db/core/flowerevent/FlowerEventEntity.kt
@@ -17,6 +17,7 @@ import java.time.LocalDate
 class FlowerEventEntity(
     val name: String,
     val address: String?,
+    val thumbnailUrl: String? = null,
     @Column(columnDefinition = "geometry(Point, 4326)")
     val pinPoint: Point,
     @Enumerated(value = EnumType.STRING)
@@ -32,6 +33,7 @@ class FlowerEventEntity(
             id = id!!,
             name = name,
             address = address,
+            thumbnailUrl = thumbnailUrl,
             pinPoint = GeoJson.Point(listOf(pinPoint.x, pinPoint.y)),
             region = region,
             homepageUrl = homepageUrl,

--- a/pida-storage/db-core/src/main/kotlin/com/pida/storage/db/core/flowerspot/FlowerSpotCafeEntity.kt
+++ b/pida-storage/db-core/src/main/kotlin/com/pida/storage/db/core/flowerspot/FlowerSpotCafeEntity.kt
@@ -22,6 +22,7 @@ class FlowerSpotCafeEntity(
     val name: String,
     val address: String?,
     val description: String?,
+    val thumbnailUrl: String? = null,
     @Column(columnDefinition = "geometry(Point, 4326)")
     val pinPoint: Point,
     @Enumerated(value = EnumType.STRING)
@@ -36,6 +37,7 @@ class FlowerSpotCafeEntity(
             name = name,
             address = address,
             description = description,
+            thumbnailUrl = thumbnailUrl,
             pinPoint = GeoJson.Point(listOf(pinPoint.x, pinPoint.y)),
             region = region,
             mapUrl = mapUrl,


### PR DESCRIPTION
## 🌱 관련 이슈
- close #123 

## 📌 작업 내용 및 특이 사항

- `/api/v2/categories/{categoryId}/items/{itemId}` 상세 API를 카테고리 공통 필드와 카테고리별 detail 블록 구조로 확장
- `EVENT`, `CAFE`, `FLOWER_SPOT` 카테고리별 상세 조회 전략을 추가
- `FLOWER_SPOT` 카테고리를 `/categories`, `/categories/{categoryId}/items` 응답에 포함하고 산책길 `LineString` 정보를 내려주도록 확장
- `t_flower_event`, `t_flower_spot_cafe` 도메인/엔티티에 `thumbnailUrl` 필드를 추가하고 category 응답에 반영

## 📝 참고

- 상세 응답은 flat nullable 구조 대신 `common + detail` 구조로 정리했습니다.
- `detail`은 category에 따라 `event`, `cafe`, `flowerSpot` 중 하나만 채워집니다.

## 📌 체크 리스트
- [x] 리뷰어를 추가하셨나요 ?
- [x] 변경사항에 대해 충분히 설명하고 있나요 ?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New GET endpoint to fetch detailed info for a specific category item
  * Added thumbnail URLs and geometry to item responses
  * Introduced "walking trail" category
  * Added recently visited counts and improved bloom-status selection in item/details

* **Tests**
  * Added extensive tests for detailed item responses and new read strategies
<!-- end of auto-generated comment: release notes by coderabbit.ai -->