### PR TITLE
[Feature] Implement flower event append and upload multipart image to S3

### DIFF
--- a/pida-clients/aws-client/src/main/kotlin/com/pida/client/aws/image/ImageS3Processor.kt
+++ b/pida-clients/aws-client/src/main/kotlin/com/pida/client/aws/image/ImageS3Processor.kt
@@ -6,6 +6,7 @@ import com.pida.support.aws.ImageS3Caller
 import com.pida.support.aws.PresignedUrlRateLimiter
 import com.pida.support.aws.S3ImageInfo
 import com.pida.support.aws.S3ImageUrl
+import com.pida.support.aws.S3UploadResult
 import org.springframework.stereotype.Component
 import software.amazon.awssdk.services.s3.model.S3Object
 import java.time.Duration
@@ -58,6 +59,30 @@ class ImageS3Processor(
             ?.let {
                 listOf(presignedGet(imageFilePath, it)) // fileName이 있으면 특정 이미지 조회
             } ?: listPresignedGets(imageFilePath) // 아니면 해당 경로 아래 모든 이미지 탐색
+    }
+
+    override fun uploadImage(
+        prefix: String,
+        prefixId: Long,
+        subPath: String,
+        contentType: String,
+        bytes: ByteArray,
+    ): S3UploadResult {
+        val filePath = imageFileConstructor.imageFilePath(prefix, prefixId)
+        val fileName = imageFileConstructor.imageFileName()
+        val s3Key = "$filePath/$subPath/$fileName"
+
+        awsS3Client.putObject(
+            bucketName = awsProperties.s3.bucket,
+            key = s3Key,
+            contentType = contentType,
+            bytes = bytes,
+        )
+
+        return S3UploadResult(
+            s3Key = s3Key,
+            publicUrl = "${awsProperties.s3.imageOriginUrl}/$s3Key",
+        )
     }
 
     override suspend fun getPreviewImage(

--- a/pida-clients/aws-client/src/main/kotlin/com/pida/client/aws/s3/AwsS3Client.kt
+++ b/pida-clients/aws-client/src/main/kotlin/com/pida/client/aws/s3/AwsS3Client.kt
@@ -1,6 +1,7 @@
 package com.pida.client.aws.s3
 
 import org.springframework.stereotype.Component
+import software.amazon.awssdk.core.sync.RequestBody
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.model.GetObjectRequest
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest
@@ -124,6 +125,22 @@ class AwsS3Client(
                 .key(key)
                 .build()
         return s3Client.headObject(request).lastModified()
+    }
+
+    fun putObject(
+        bucketName: String,
+        key: String,
+        contentType: String,
+        bytes: ByteArray,
+    ) {
+        val request =
+            PutObjectRequest
+                .builder()
+                .bucket(bucketName)
+                .key(key)
+                .contentType(contentType)
+                .build()
+        s3Client.putObject(request, RequestBody.fromBytes(bytes))
     }
 
     fun getObjectAsBytes(

--- a/pida-core/core-api/src/main/kotlin/com/pida/presentation/v2/flowerevent/FlowerEventController.kt
+++ b/pida-core/core-api/src/main/kotlin/com/pida/presentation/v2/flowerevent/FlowerEventController.kt
@@ -30,7 +30,7 @@ class FlowerEventController(
     suspend fun addFlowerEvents(
         @RequestBody data: List<FlowerEventCreateRequest>,
     ) {
-        flowerEventFacade.processBatch(data.map { it.toNewFlowerEvent() })
+        flowerEventFacade.addAll(data.map { it.toNewFlowerEvent() })
     }
 
     @PostMapping("/flower-event/{eventId}/thumbnail", consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])

--- a/pida-core/core-api/src/main/kotlin/com/pida/presentation/v2/flowerevent/FlowerEventController.kt
+++ b/pida-core/core-api/src/main/kotlin/com/pida/presentation/v2/flowerevent/FlowerEventController.kt
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.multipart.MultipartFile
 
-@Tag(name = "🌸 Flower Event Admin API", description = "관리자용 이벤트 관리 API")
+@Tag(name = "🌸 Flower Spot Admin API", description = "관리자용 벚꽃 연관 데이터 관리 API")
 @RestController
 @RequestMapping("/test")
 class FlowerEventController(

--- a/pida-core/core-api/src/main/kotlin/com/pida/presentation/v2/flowerevent/FlowerEventController.kt
+++ b/pida-core/core-api/src/main/kotlin/com/pida/presentation/v2/flowerevent/FlowerEventController.kt
@@ -24,10 +24,8 @@ class FlowerEventController(
     @PostMapping("/flower-event")
     @ResponseStatus(HttpStatus.CREATED)
     @Operation(
-        summary = "꽃 이벤트 일괄 등록",
-        description =
-            "꽃 이벤트 데이터를 일괄 등록합니다.\n\n" +
-                "- 썸네일 이미지는 등록 후 개별 업로드 API를 사용해주세요.",
+        summary = "벚꽃 축제 일괄 등록",
+        description = "벚꽃 축제 데이터를 일괄 등록합니다. 썸네일 이미지는 등록 후 개별 업로드 API를 사용해주세요.",
     )
     suspend fun addFlowerEvents(
         @RequestBody data: List<FlowerEventCreateRequest>,
@@ -38,8 +36,8 @@ class FlowerEventController(
     @PostMapping("/flower-event/{eventId}/thumbnail", consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
     @ResponseStatus(HttpStatus.CREATED)
     @Operation(
-        summary = "꽃 이벤트 썸네일 업로드",
-        description = "특정 꽃 이벤트의 썸네일 이미지를 업로드합니다.",
+        summary = "벚꽃 축제 썸네일 업로드",
+        description = "벚꽃 축제 썸네일 이미지를 업로드합니다.",
     )
     suspend fun uploadThumbnail(
         @PathVariable eventId: Long,

--- a/pida-core/core-api/src/main/kotlin/com/pida/presentation/v2/flowerevent/FlowerEventController.kt
+++ b/pida-core/core-api/src/main/kotlin/com/pida/presentation/v2/flowerevent/FlowerEventController.kt
@@ -1,0 +1,50 @@
+package com.pida.presentation.v2.flowerevent
+
+import com.pida.flowerevent.FlowerEventAdminFacade
+import com.pida.presentation.v2.flowerevent.request.FlowerEventCreateRequest
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestPart
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.multipart.MultipartFile
+
+@Tag(name = "🌸 Flower Event Admin API", description = "관리자용 이벤트 관리 API")
+@RestController
+@RequestMapping("/test")
+class FlowerEventController(
+    private val flowerEventAdminFacade: FlowerEventAdminFacade,
+) {
+    @PostMapping("/flower-event")
+    @ResponseStatus(HttpStatus.CREATED)
+    @Operation(
+        summary = "꽃 이벤트 일괄 등록",
+        description =
+            "꽃 이벤트 데이터를 일괄 등록합니다.\n\n" +
+                "- 썸네일 이미지는 등록 후 개별 업로드 API를 사용해주세요.",
+    )
+    suspend fun addFlowerEvents(
+        @RequestBody data: List<FlowerEventCreateRequest>,
+    ) {
+        flowerEventAdminFacade.processBatch(data.map { it.toNewFlowerEvent() })
+    }
+
+    @PostMapping("/flower-event/{eventId}/thumbnail", consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
+    @ResponseStatus(HttpStatus.CREATED)
+    @Operation(
+        summary = "꽃 이벤트 썸네일 업로드",
+        description = "특정 꽃 이벤트의 썸네일 이미지를 업로드합니다.",
+    )
+    suspend fun uploadThumbnail(
+        @PathVariable eventId: Long,
+        @RequestPart("thumbnail") thumbnail: MultipartFile,
+    ) {
+        flowerEventAdminFacade.uploadThumbnail(eventId, thumbnail.bytes)
+    }
+}

--- a/pida-core/core-api/src/main/kotlin/com/pida/presentation/v2/flowerevent/FlowerEventController.kt
+++ b/pida-core/core-api/src/main/kotlin/com/pida/presentation/v2/flowerevent/FlowerEventController.kt
@@ -1,6 +1,6 @@
 package com.pida.presentation.v2.flowerevent
 
-import com.pida.flowerevent.FlowerEventAdminFacade
+import com.pida.flowerevent.FlowerEventFacade
 import com.pida.presentation.v2.flowerevent.request.FlowerEventCreateRequest
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
@@ -19,7 +19,7 @@ import org.springframework.web.multipart.MultipartFile
 @RestController
 @RequestMapping("/test")
 class FlowerEventController(
-    private val flowerEventAdminFacade: FlowerEventAdminFacade,
+    private val flowerEventFacade: FlowerEventFacade,
 ) {
     @PostMapping("/flower-event")
     @ResponseStatus(HttpStatus.CREATED)
@@ -30,7 +30,7 @@ class FlowerEventController(
     suspend fun addFlowerEvents(
         @RequestBody data: List<FlowerEventCreateRequest>,
     ) {
-        flowerEventAdminFacade.processBatch(data.map { it.toNewFlowerEvent() })
+        flowerEventFacade.processBatch(data.map { it.toNewFlowerEvent() })
     }
 
     @PostMapping("/flower-event/{eventId}/thumbnail", consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
@@ -43,6 +43,6 @@ class FlowerEventController(
         @PathVariable eventId: Long,
         @RequestPart("thumbnail") thumbnail: MultipartFile,
     ) {
-        flowerEventAdminFacade.uploadThumbnail(eventId, thumbnail.bytes)
+        flowerEventFacade.uploadThumbnail(eventId, thumbnail.bytes)
     }
 }

--- a/pida-core/core-api/src/main/kotlin/com/pida/presentation/v2/flowerevent/FlowerEventController.kt
+++ b/pida-core/core-api/src/main/kotlin/com/pida/presentation/v2/flowerevent/FlowerEventController.kt
@@ -17,7 +17,7 @@ import org.springframework.web.multipart.MultipartFile
 
 @Tag(name = "🌸 Flower Spot Admin API", description = "관리자용 벚꽃 연관 데이터 관리 API")
 @RestController
-@RequestMapping("/test")
+@RequestMapping("/admin")
 class FlowerEventController(
     private val flowerEventFacade: FlowerEventFacade,
 ) {

--- a/pida-core/core-api/src/main/kotlin/com/pida/presentation/v2/flowerevent/request/FlowerEventCreateRequest.kt
+++ b/pida-core/core-api/src/main/kotlin/com/pida/presentation/v2/flowerevent/request/FlowerEventCreateRequest.kt
@@ -1,0 +1,53 @@
+package com.pida.presentation.v2.flowerevent.request
+
+import com.pida.flowerevent.NewFlowerEvent
+import com.pida.support.geo.Region
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDate
+
+@Schema(description = "꽃 이벤트 생성 요청")
+data class FlowerEventCreateRequest(
+    @Schema(description = "이벤트 이름", example = "여의도 벚꽃축제")
+    val name: String,
+    @Schema(description = "주소", example = "서울특별시 영등포구 여의도동", required = false)
+    val address: String?,
+    @Schema(description = "경도 (longitude)", example = "126.9246")
+    val longitude: Double,
+    @Schema(description = "위도 (latitude)", example = "37.5284")
+    val latitude: Double,
+    @Schema(description = "지역", example = "SEOUL")
+    val region: Region,
+    @Schema(description = "홈페이지 URL", example = "https://example.com", required = false)
+    val homepageUrl: String?,
+    @Schema(description = "시작일", example = "2026-04-01")
+    val startDate: LocalDate,
+    @Schema(description = "종료일", example = "2026-04-07")
+    val endDate: LocalDate,
+    @Schema(description = "카테고리 ID", example = "1")
+    val categoryId: Long,
+) {
+    init {
+        if (!homepageUrl.isNullOrBlank()) {
+            require(URL_PATTERN.matches(homepageUrl)) {
+                "Invalid homepage URL format: $homepageUrl"
+            }
+        }
+    }
+
+    fun toNewFlowerEvent(): NewFlowerEvent =
+        NewFlowerEvent(
+            name = name,
+            address = address,
+            longitude = longitude,
+            latitude = latitude,
+            region = region,
+            homepageUrl = homepageUrl,
+            startDate = startDate,
+            endDate = endDate,
+            categoryId = categoryId,
+        )
+
+    companion object {
+        private val URL_PATTERN = Regex("^https?://[\\w\\-.]+(:\\d+)?(/\\S*)?$")
+    }
+}

--- a/pida-core/core-api/src/main/kotlin/com/pida/presentation/v2/flowerspotcafe/FlowerSpotCafeController.kt
+++ b/pida-core/core-api/src/main/kotlin/com/pida/presentation/v2/flowerspotcafe/FlowerSpotCafeController.kt
@@ -30,7 +30,7 @@ class FlowerSpotCafeController(
     suspend fun addFlowerSpotCafes(
         @RequestBody data: List<FlowerSpotCafeCreateRequest>,
     ) {
-        flowerSpotCafeFacade.processBatch(data.map { it.toNewFlowerSpotCafe() })
+        flowerSpotCafeFacade.addAll(data.map { it.toNewFlowerSpotCafe() })
     }
 
     @PostMapping("/flower-spot-cafe/{cafeId}/thumbnail", consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])

--- a/pida-core/core-api/src/main/kotlin/com/pida/presentation/v2/flowerspotcafe/FlowerSpotCafeController.kt
+++ b/pida-core/core-api/src/main/kotlin/com/pida/presentation/v2/flowerspotcafe/FlowerSpotCafeController.kt
@@ -17,7 +17,7 @@ import org.springframework.web.multipart.MultipartFile
 
 @Tag(name = "🌸 Flower Spot Admin API", description = "관리자용 벚꽃 연관 데이터 관리 API")
 @RestController
-@RequestMapping("/test")
+@RequestMapping("/admin")
 class FlowerSpotCafeController(
     private val flowerSpotCafeFacade: FlowerSpotCafeFacade,
 ) {

--- a/pida-core/core-api/src/main/kotlin/com/pida/presentation/v2/flowerspotcafe/FlowerSpotCafeController.kt
+++ b/pida-core/core-api/src/main/kotlin/com/pida/presentation/v2/flowerspotcafe/FlowerSpotCafeController.kt
@@ -1,6 +1,6 @@
 package com.pida.presentation.v2.flowerspotcafe
 
-import com.pida.flowerspot.FlowerSpotCafeAdminFacade
+import com.pida.flowerspot.FlowerSpotCafeFacade
 import com.pida.presentation.v2.flowerspotcafe.request.FlowerSpotCafeCreateRequest
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
@@ -19,7 +19,7 @@ import org.springframework.web.multipart.MultipartFile
 @RestController
 @RequestMapping("/test")
 class FlowerSpotCafeController(
-    private val flowerSpotCafeAdminFacade: FlowerSpotCafeAdminFacade,
+    private val flowerSpotCafeFacade: FlowerSpotCafeFacade,
 ) {
     @PostMapping("/flower-spot-cafe")
     @ResponseStatus(HttpStatus.CREATED)
@@ -30,7 +30,7 @@ class FlowerSpotCafeController(
     suspend fun addFlowerSpotCafes(
         @RequestBody data: List<FlowerSpotCafeCreateRequest>,
     ) {
-        flowerSpotCafeAdminFacade.processBatch(data.map { it.toNewFlowerSpotCafe() })
+        flowerSpotCafeFacade.processBatch(data.map { it.toNewFlowerSpotCafe() })
     }
 
     @PostMapping("/flower-spot-cafe/{cafeId}/thumbnail", consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
@@ -43,6 +43,6 @@ class FlowerSpotCafeController(
         @PathVariable cafeId: Long,
         @RequestPart("thumbnail") thumbnail: MultipartFile,
     ) {
-        flowerSpotCafeAdminFacade.uploadThumbnail(cafeId, thumbnail.bytes)
+        flowerSpotCafeFacade.uploadThumbnail(cafeId, thumbnail.bytes)
     }
 }

--- a/pida-core/core-api/src/main/kotlin/com/pida/presentation/v2/flowerspotcafe/FlowerSpotCafeController.kt
+++ b/pida-core/core-api/src/main/kotlin/com/pida/presentation/v2/flowerspotcafe/FlowerSpotCafeController.kt
@@ -1,0 +1,48 @@
+package com.pida.presentation.v2.flowerspotcafe
+
+import com.pida.flowerspot.FlowerSpotCafeAdminFacade
+import com.pida.presentation.v2.flowerspotcafe.request.FlowerSpotCafeCreateRequest
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestPart
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.multipart.MultipartFile
+
+@Tag(name = "🌸 Flower Spot Admin API", description = "관리자용 벚꽃 연관 데이터 관리 API")
+@RestController
+@RequestMapping("/test")
+class FlowerSpotCafeController(
+    private val flowerSpotCafeAdminFacade: FlowerSpotCafeAdminFacade,
+) {
+    @PostMapping("/flower-spot-cafe")
+    @ResponseStatus(HttpStatus.CREATED)
+    @Operation(
+        summary = "벚꽃 명소 카페 일괄 등록",
+        description = "벚꽃 명소 카페 데이터를 일괄 등록합니다. 썸네일 이미지는 등록 후 개별 업로드 API를 사용해주세요.",
+    )
+    suspend fun addFlowerSpotCafes(
+        @RequestBody data: List<FlowerSpotCafeCreateRequest>,
+    ) {
+        flowerSpotCafeAdminFacade.processBatch(data.map { it.toNewFlowerSpotCafe() })
+    }
+
+    @PostMapping("/flower-spot-cafe/{cafeId}/thumbnail", consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
+    @ResponseStatus(HttpStatus.CREATED)
+    @Operation(
+        summary = "벚꽃 명소 카페 썸네일 업로드",
+        description = "벚꽃 명소 카페 썸네일 이미지를 업로드합니다.",
+    )
+    suspend fun uploadThumbnail(
+        @PathVariable cafeId: Long,
+        @RequestPart("thumbnail") thumbnail: MultipartFile,
+    ) {
+        flowerSpotCafeAdminFacade.uploadThumbnail(cafeId, thumbnail.bytes)
+    }
+}

--- a/pida-core/core-api/src/main/kotlin/com/pida/presentation/v2/flowerspotcafe/request/FlowerSpotCafeCreateRequest.kt
+++ b/pida-core/core-api/src/main/kotlin/com/pida/presentation/v2/flowerspotcafe/request/FlowerSpotCafeCreateRequest.kt
@@ -1,0 +1,49 @@
+package com.pida.presentation.v2.flowerspotcafe.request
+
+import com.pida.flowerspot.NewFlowerSpotCafe
+import com.pida.support.geo.Region
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "꽃 명소 카페 생성 요청")
+data class FlowerSpotCafeCreateRequest(
+    @Schema(description = "꽃 명소 ID", example = "1")
+    val flowerSpotId: Long,
+    @Schema(description = "카페 이름", example = "벚꽃 카페")
+    val name: String,
+    @Schema(description = "주소", example = "서울특별시 영등포구 여의도동", required = false)
+    val address: String?,
+    @Schema(description = "설명", example = "벚꽃 명소 근처 분위기 좋은 카페", required = false)
+    val description: String?,
+    @Schema(description = "경도 (longitude)", example = "126.9246")
+    val longitude: Double,
+    @Schema(description = "위도 (latitude)", example = "37.5284")
+    val latitude: Double,
+    @Schema(description = "지역", example = "SEOUL")
+    val region: Region,
+    @Schema(description = "지도 URL", example = "https://map.naver.com/example", required = false)
+    val mapUrl: String?,
+) {
+    init {
+        if (!mapUrl.isNullOrBlank()) {
+            require(URL_PATTERN.matches(mapUrl)) {
+                "Invalid map URL format: $mapUrl"
+            }
+        }
+    }
+
+    fun toNewFlowerSpotCafe(): NewFlowerSpotCafe =
+        NewFlowerSpotCafe(
+            flowerSpotId = flowerSpotId,
+            name = name,
+            address = address,
+            description = description,
+            longitude = longitude,
+            latitude = latitude,
+            region = region,
+            mapUrl = mapUrl,
+        )
+
+    companion object {
+        private val URL_PATTERN = Regex("^https?://[\\w\\-.]+(:\\d+)?(/\\S*)?$")
+    }
+}

--- a/pida-core/core-domain/src/main/kotlin/com/pida/flowerevent/FlowerEventAdminFacade.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/flowerevent/FlowerEventAdminFacade.kt
@@ -1,0 +1,31 @@
+package com.pida.flowerevent
+
+import com.pida.support.aws.ImageS3Caller
+import org.springframework.stereotype.Service
+
+@Service
+class FlowerEventAdminFacade(
+    private val flowerEventFinder: FlowerEventFinder,
+    private val flowerEventAppender: FlowerEventAppender,
+    private val imageS3Caller: ImageS3Caller,
+) {
+    suspend fun processBatch(requests: List<NewFlowerEvent>) = requests.forEach { flowerEventAppender.add(it.toDomain()) }
+
+    suspend fun uploadThumbnail(
+        eventId: Long,
+        imageBytes: ByteArray,
+    ) {
+        flowerEventFinder.readBy(eventId)
+
+        val uploadResult =
+            imageS3Caller.uploadImage(
+                prefix = "flowerevent",
+                prefixId = eventId,
+                subPath = "thumbnail",
+                contentType = "image/jpeg",
+                bytes = imageBytes,
+            )
+
+        flowerEventAppender.updateThumbnailUrl(eventId, uploadResult.publicUrl)
+    }
+}

--- a/pida-core/core-domain/src/main/kotlin/com/pida/flowerevent/FlowerEventAppender.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/flowerevent/FlowerEventAppender.kt
@@ -1,0 +1,17 @@
+package com.pida.flowerevent
+
+import org.springframework.stereotype.Component
+
+@Component
+class FlowerEventAppender(
+    private val flowerEventRepository: FlowerEventRepository,
+) {
+    suspend fun add(event: FlowerEvent): FlowerEvent = flowerEventRepository.save(event)
+
+    suspend fun updateThumbnailUrl(
+        eventId: Long,
+        thumbnailUrl: String,
+    ) {
+        flowerEventRepository.updateThumbnailUrl(eventId, thumbnailUrl)
+    }
+}

--- a/pida-core/core-domain/src/main/kotlin/com/pida/flowerevent/FlowerEventFacade.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/flowerevent/FlowerEventFacade.kt
@@ -4,7 +4,7 @@ import com.pida.support.aws.ImageS3Caller
 import org.springframework.stereotype.Service
 
 @Service
-class FlowerEventAdminFacade(
+class FlowerEventFacade(
     private val flowerEventFinder: FlowerEventFinder,
     private val flowerEventAppender: FlowerEventAppender,
     private val imageS3Caller: ImageS3Caller,

--- a/pida-core/core-domain/src/main/kotlin/com/pida/flowerevent/FlowerEventFacade.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/flowerevent/FlowerEventFacade.kt
@@ -9,7 +9,7 @@ class FlowerEventFacade(
     private val flowerEventAppender: FlowerEventAppender,
     private val imageS3Caller: ImageS3Caller,
 ) {
-    suspend fun processBatch(requests: List<NewFlowerEvent>) = requests.forEach { flowerEventAppender.add(it.toDomain()) }
+    suspend fun addAll(requests: List<NewFlowerEvent>) = requests.forEach { flowerEventAppender.add(it.toDomain()) }
 
     suspend fun uploadThumbnail(
         eventId: Long,

--- a/pida-core/core-domain/src/main/kotlin/com/pida/flowerevent/FlowerEventRepository.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/flowerevent/FlowerEventRepository.kt
@@ -17,4 +17,11 @@ interface FlowerEventRepository {
         longitude: Double,
         radiusMeters: Double,
     ): List<FlowerEvent>
+
+    suspend fun save(event: FlowerEvent): FlowerEvent
+
+    suspend fun updateThumbnailUrl(
+        eventId: Long,
+        thumbnailUrl: String,
+    )
 }

--- a/pida-core/core-domain/src/main/kotlin/com/pida/flowerevent/NewFlowerEvent.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/flowerevent/NewFlowerEvent.kt
@@ -1,0 +1,32 @@
+package com.pida.flowerevent
+
+import com.pida.support.geo.GeoJson
+import com.pida.support.geo.Region
+import java.time.LocalDate
+
+data class NewFlowerEvent(
+    val name: String,
+    val address: String?,
+    val longitude: Double,
+    val latitude: Double,
+    val region: Region,
+    val homepageUrl: String?,
+    val startDate: LocalDate,
+    val endDate: LocalDate,
+    val categoryId: Long,
+) {
+    fun toDomain(): FlowerEvent =
+        FlowerEvent(
+            id = 0,
+            name = name,
+            address = address,
+            thumbnailUrl = null,
+            pinPoint = GeoJson.Point(listOf(longitude, latitude)),
+            region = region,
+            homepageUrl = homepageUrl,
+            startDate = startDate,
+            endDate = endDate,
+            categoryId = categoryId,
+            deletedAt = null,
+        )
+}

--- a/pida-core/core-domain/src/main/kotlin/com/pida/flowerspot/FlowerSpotCafeAdminFacade.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/flowerspot/FlowerSpotCafeAdminFacade.kt
@@ -1,0 +1,31 @@
+package com.pida.flowerspot
+
+import com.pida.support.aws.ImageS3Caller
+import org.springframework.stereotype.Service
+
+@Service
+class FlowerSpotCafeAdminFacade(
+    private val flowerSpotCafeFinder: FlowerSpotCafeFinder,
+    private val flowerSpotCafeAppender: FlowerSpotCafeAppender,
+    private val imageS3Caller: ImageS3Caller,
+) {
+    suspend fun processBatch(requests: List<NewFlowerSpotCafe>) = requests.forEach { flowerSpotCafeAppender.add(it.toDomain()) }
+
+    suspend fun uploadThumbnail(
+        cafeId: Long,
+        imageBytes: ByteArray,
+    ) {
+        flowerSpotCafeFinder.readBy(cafeId)
+
+        val uploadResult =
+            imageS3Caller.uploadImage(
+                prefix = "flowerspotcafe",
+                prefixId = cafeId,
+                subPath = "thumbnail",
+                contentType = "image/jpeg",
+                bytes = imageBytes,
+            )
+
+        flowerSpotCafeAppender.updateThumbnailUrl(cafeId, uploadResult.publicUrl)
+    }
+}

--- a/pida-core/core-domain/src/main/kotlin/com/pida/flowerspot/FlowerSpotCafeAppender.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/flowerspot/FlowerSpotCafeAppender.kt
@@ -1,0 +1,17 @@
+package com.pida.flowerspot
+
+import org.springframework.stereotype.Component
+
+@Component
+class FlowerSpotCafeAppender(
+    private val flowerSpotCafeRepository: FlowerSpotCafeRepository,
+) {
+    suspend fun add(cafe: FlowerSpotCafe): FlowerSpotCafe = flowerSpotCafeRepository.save(cafe)
+
+    suspend fun updateThumbnailUrl(
+        cafeId: Long,
+        thumbnailUrl: String,
+    ) {
+        flowerSpotCafeRepository.updateThumbnailUrl(cafeId, thumbnailUrl)
+    }
+}

--- a/pida-core/core-domain/src/main/kotlin/com/pida/flowerspot/FlowerSpotCafeFacade.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/flowerspot/FlowerSpotCafeFacade.kt
@@ -9,7 +9,7 @@ class FlowerSpotCafeFacade(
     private val flowerSpotCafeAppender: FlowerSpotCafeAppender,
     private val imageS3Caller: ImageS3Caller,
 ) {
-    suspend fun processBatch(requests: List<NewFlowerSpotCafe>) = requests.forEach { flowerSpotCafeAppender.add(it.toDomain()) }
+    suspend fun addAll(requests: List<NewFlowerSpotCafe>) = requests.forEach { flowerSpotCafeAppender.add(it.toDomain()) }
 
     suspend fun uploadThumbnail(
         cafeId: Long,

--- a/pida-core/core-domain/src/main/kotlin/com/pida/flowerspot/FlowerSpotCafeFacade.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/flowerspot/FlowerSpotCafeFacade.kt
@@ -4,7 +4,7 @@ import com.pida.support.aws.ImageS3Caller
 import org.springframework.stereotype.Service
 
 @Service
-class FlowerSpotCafeAdminFacade(
+class FlowerSpotCafeFacade(
     private val flowerSpotCafeFinder: FlowerSpotCafeFinder,
     private val flowerSpotCafeAppender: FlowerSpotCafeAppender,
     private val imageS3Caller: ImageS3Caller,

--- a/pida-core/core-domain/src/main/kotlin/com/pida/flowerspot/FlowerSpotCafeRepository.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/flowerspot/FlowerSpotCafeRepository.kt
@@ -8,4 +8,11 @@ interface FlowerSpotCafeRepository {
     suspend fun findAllByLocation(location: FlowerSpotLocation): List<FlowerSpotCafe>
 
     suspend fun findAllByFlowerSpotId(flowerSpotId: Long): List<FlowerSpotCafe>
+
+    suspend fun save(cafe: FlowerSpotCafe): FlowerSpotCafe
+
+    suspend fun updateThumbnailUrl(
+        cafeId: Long,
+        thumbnailUrl: String,
+    )
 }

--- a/pida-core/core-domain/src/main/kotlin/com/pida/flowerspot/NewFlowerSpotCafe.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/flowerspot/NewFlowerSpotCafe.kt
@@ -1,0 +1,29 @@
+package com.pida.flowerspot
+
+import com.pida.support.geo.GeoJson
+import com.pida.support.geo.Region
+
+data class NewFlowerSpotCafe(
+    val flowerSpotId: Long,
+    val name: String,
+    val address: String?,
+    val description: String?,
+    val longitude: Double,
+    val latitude: Double,
+    val region: Region,
+    val mapUrl: String?,
+) {
+    fun toDomain(): FlowerSpotCafe =
+        FlowerSpotCafe(
+            id = 0,
+            flowerSpotId = flowerSpotId,
+            name = name,
+            address = address,
+            description = description,
+            thumbnailUrl = null,
+            pinPoint = GeoJson.Point(listOf(longitude, latitude)),
+            region = region,
+            mapUrl = mapUrl,
+            deletedAt = null,
+        )
+}

--- a/pida-core/core-domain/src/main/kotlin/com/pida/support/aws/ImageS3Caller.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/support/aws/ImageS3Caller.kt
@@ -32,4 +32,22 @@ interface ImageS3Caller {
         prefix: String,
         prefixId: Long,
     ): S3ImageInfo?
+
+    /**
+     * 서버 사이드 이미지 업로드
+     *
+     * @param prefix [String] 도메인
+     * @param prefixId [Long] 도메인 ID
+     * @param subPath [String] 추가 하위 경로 (e.g. "thumbnail")
+     * @param contentType [String] 이미지 Content-Type
+     * @param bytes [ByteArray] 이미지 데이터
+     * @return 업로드된 이미지의 공개 URL
+     */
+    fun uploadImage(
+        prefix: String,
+        prefixId: Long,
+        subPath: String,
+        contentType: String,
+        bytes: ByteArray,
+    ): S3UploadResult
 }

--- a/pida-core/core-domain/src/main/kotlin/com/pida/support/aws/S3UploadResult.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/support/aws/S3UploadResult.kt
@@ -1,0 +1,6 @@
+package com.pida.support.aws
+
+data class S3UploadResult(
+    val s3Key: String,
+    val publicUrl: String,
+)

--- a/pida-storage/db-core/src/main/kotlin/com/pida/storage/db/core/flowerevent/FlowerEventCoreRepository.kt
+++ b/pida-storage/db-core/src/main/kotlin/com/pida/storage/db/core/flowerevent/FlowerEventCoreRepository.kt
@@ -4,15 +4,24 @@ import com.pida.flowerevent.FlowerEvent
 import com.pida.flowerevent.FlowerEventRepository
 import com.pida.flowerspot.FlowerSpotLocation
 import com.pida.storage.db.core.support.findByIdAndDeletedAtIsNullOrElseThrow
+import com.pida.support.geo.GeoJson
 import com.pida.support.tx.TransactionTemplates
 import com.pida.support.tx.coExecute
+import org.locationtech.jts.geom.Coordinate
+import org.locationtech.jts.geom.GeometryFactory
+import org.locationtech.jts.geom.PrecisionModel
 import org.springframework.stereotype.Repository
 
 @Repository
 class FlowerEventCoreRepository(
     private val flowerEventJpaRepository: FlowerEventJpaRepository,
+    private val flowerEventCustomRepository: FlowerEventCustomRepository,
     private val tx: TransactionTemplates,
 ) : FlowerEventRepository {
+    companion object {
+        private val GEOMETRY_FACTORY = GeometryFactory(PrecisionModel(), 4326)
+    }
+
     override suspend fun findBy(eventId: Long): FlowerEvent =
         tx.reader.coExecute {
             flowerEventJpaRepository
@@ -52,4 +61,31 @@ class FlowerEventCoreRepository(
                 .findWithinRadius(latitude, longitude, radiusMeters)
                 .map { it.toFlowerEvent() }
         }
+
+    override suspend fun save(event: FlowerEvent): FlowerEvent =
+        tx.writer.coExecute {
+            val point = event.pinPoint as GeoJson.Point
+            val entity =
+                FlowerEventEntity(
+                    name = event.name,
+                    address = event.address,
+                    thumbnailUrl = event.thumbnailUrl,
+                    pinPoint = GEOMETRY_FACTORY.createPoint(Coordinate(point.coordinates[0], point.coordinates[1])),
+                    region = event.region,
+                    homepageUrl = event.homepageUrl,
+                    startDate = event.startDate,
+                    endDate = event.endDate,
+                    categoryId = event.categoryId,
+                )
+            flowerEventJpaRepository.save(entity).toFlowerEvent()
+        }
+
+    override suspend fun updateThumbnailUrl(
+        eventId: Long,
+        thumbnailUrl: String,
+    ) {
+        tx.writer.coExecute {
+            flowerEventCustomRepository.updateThumbnailUrl(eventId, thumbnailUrl)
+        }
+    }
 }

--- a/pida-storage/db-core/src/main/kotlin/com/pida/storage/db/core/flowerevent/FlowerEventCustomRepository.kt
+++ b/pida-storage/db-core/src/main/kotlin/com/pida/storage/db/core/flowerevent/FlowerEventCustomRepository.kt
@@ -1,0 +1,27 @@
+package com.pida.storage.db.core.flowerevent
+
+import com.linecorp.kotlinjdsl.dsl.jpql.jpql
+import com.linecorp.kotlinjdsl.render.RenderContext
+import com.linecorp.kotlinjdsl.support.spring.data.jpa.extension.createQuery
+import jakarta.persistence.EntityManager
+import org.springframework.stereotype.Repository
+
+@Repository
+class FlowerEventCustomRepository(
+    private val entityManager: EntityManager,
+    private val jdslRenderContext: RenderContext,
+) {
+    fun updateThumbnailUrl(
+        eventId: Long,
+        thumbnailUrl: String,
+    ) {
+        val query =
+            jpql {
+                update(entity(FlowerEventEntity::class))
+                    .set(path(FlowerEventEntity::thumbnailUrl), thumbnailUrl)
+                    .where(path(FlowerEventEntity::id).eq(eventId))
+            }
+
+        entityManager.createQuery(query, jdslRenderContext).executeUpdate()
+    }
+}

--- a/pida-storage/db-core/src/main/kotlin/com/pida/storage/db/core/flowerspot/FlowerSpotCafeCoreRepository.kt
+++ b/pida-storage/db-core/src/main/kotlin/com/pida/storage/db/core/flowerspot/FlowerSpotCafeCoreRepository.kt
@@ -4,15 +4,24 @@ import com.pida.flowerspot.FlowerSpotCafe
 import com.pida.flowerspot.FlowerSpotCafeRepository
 import com.pida.flowerspot.FlowerSpotLocation
 import com.pida.storage.db.core.support.findByIdAndDeletedAtIsNullOrElseThrow
+import com.pida.support.geo.GeoJson
 import com.pida.support.tx.TransactionTemplates
 import com.pida.support.tx.coExecute
+import org.locationtech.jts.geom.Coordinate
+import org.locationtech.jts.geom.GeometryFactory
+import org.locationtech.jts.geom.PrecisionModel
 import org.springframework.stereotype.Repository
 
 @Repository
 class FlowerSpotCafeCoreRepository(
     private val flowerSpotCafeJpaRepository: FlowerSpotCafeJpaRepository,
+    private val flowerSpotCafeCustomRepository: FlowerSpotCafeCustomRepository,
     private val tx: TransactionTemplates,
 ) : FlowerSpotCafeRepository {
+    companion object {
+        private val GEOMETRY_FACTORY = GeometryFactory(PrecisionModel(), 4326)
+    }
+
     override suspend fun findBy(cafeId: Long): FlowerSpotCafe =
         tx.reader.coExecute {
             flowerSpotCafeJpaRepository
@@ -44,4 +53,30 @@ class FlowerSpotCafeCoreRepository(
                 .findByFlowerSpotIdAndDeletedAtIsNull(flowerSpotId)
                 .map { it.toFlowerSpotCafe() }
         }
+
+    override suspend fun save(cafe: FlowerSpotCafe): FlowerSpotCafe =
+        tx.writer.coExecute {
+            val point = cafe.pinPoint as GeoJson.Point
+            val entity =
+                FlowerSpotCafeEntity(
+                    flowerSpotId = cafe.flowerSpotId,
+                    name = cafe.name,
+                    address = cafe.address,
+                    description = cafe.description,
+                    thumbnailUrl = cafe.thumbnailUrl,
+                    pinPoint = GEOMETRY_FACTORY.createPoint(Coordinate(point.coordinates[0], point.coordinates[1])),
+                    region = cafe.region,
+                    mapUrl = cafe.mapUrl,
+                )
+            flowerSpotCafeJpaRepository.save(entity).toFlowerSpotCafe()
+        }
+
+    override suspend fun updateThumbnailUrl(
+        cafeId: Long,
+        thumbnailUrl: String,
+    ) {
+        tx.writer.coExecute {
+            flowerSpotCafeCustomRepository.updateThumbnailUrl(cafeId, thumbnailUrl)
+        }
+    }
 }

--- a/pida-storage/db-core/src/main/kotlin/com/pida/storage/db/core/flowerspot/FlowerSpotCafeCustomRepository.kt
+++ b/pida-storage/db-core/src/main/kotlin/com/pida/storage/db/core/flowerspot/FlowerSpotCafeCustomRepository.kt
@@ -1,0 +1,27 @@
+package com.pida.storage.db.core.flowerspot
+
+import com.linecorp.kotlinjdsl.dsl.jpql.jpql
+import com.linecorp.kotlinjdsl.render.RenderContext
+import com.linecorp.kotlinjdsl.support.spring.data.jpa.extension.createQuery
+import jakarta.persistence.EntityManager
+import org.springframework.stereotype.Repository
+
+@Repository
+class FlowerSpotCafeCustomRepository(
+    private val entityManager: EntityManager,
+    private val jdslRenderContext: RenderContext,
+) {
+    fun updateThumbnailUrl(
+        cafeId: Long,
+        thumbnailUrl: String,
+    ) {
+        val query =
+            jpql {
+                update(entity(FlowerSpotCafeEntity::class))
+                    .set(path(FlowerSpotCafeEntity::thumbnailUrl), thumbnailUrl)
+                    .where(path(FlowerSpotCafeEntity::id).eq(cafeId))
+            }
+
+        entityManager.createQuery(query, jdslRenderContext).executeUpdate()
+    }
+}


### PR DESCRIPTION
## 🌱 관련 이슈
- close # 

## 📌 작업 내용 및 특이 사항

- 벚꽃 축제, 카페 데이터 저장하는 관리자용 API 추가
- 축제, 카페 멀티파트 이미지 직접 업로드하는 API 추가

## 📝 참고

- 

## 📌 체크 리스트
<!-- 
    조건을 만족하셨다면 공백 대신 x 를 넣어주세요.
    ex:
    - [x] ~~
    - [ ] ~~
-->
- [ ] 리뷰어를 추가하셨나요 ?
- [ ] 변경사항에 대해 충분히 설명하고 있나요 ?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin APIs for bulk creation of flower events and flower spot cafes
  * Admin endpoints to upload thumbnails for events and cafes
  * Image upload to S3 with generated public URLs for thumbnails
  * Geolocation support (latitude/longitude + region) for events and cafes
  * Request validation for submitted URLs and creation data to catch invalid input
<!-- end of auto-generated comment: release notes by coderabbit.ai -->