### PR TITLE
[Refactor] Implement Non-blocking preview image lookup and image meta data persisted

### DIFF
--- a/pida-clients/aws-client/build.gradle.kts
+++ b/pida-clients/aws-client/build.gradle.kts
@@ -2,6 +2,7 @@ dependencies {
     compileOnly(libs.spring.boot.starter.web)
 
     implementation(libs.bundles.aws.client)
+    implementation(libs.kotlinx.coroutine.core)
     implementation(project(":pida-core:core-domain"))
 
     testImplementation(libs.spring.boot.starter.web)

--- a/pida-clients/aws-client/src/main/kotlin/com/pida/client/aws/config/AwsConfig.kt
+++ b/pida-clients/aws-client/src/main/kotlin/com/pida/client/aws/config/AwsConfig.kt
@@ -8,6 +8,7 @@ import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
 import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.s3.S3AsyncClient
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.presigner.S3Presigner
 import java.net.URI
@@ -36,6 +37,20 @@ class AwsConfig(
     fun s3Client(): S3Client {
         val client =
             S3Client
+                .builder()
+                .credentialsProvider(credentialProvider())
+                .region(Region.of(awsProperties.region))
+        awsProperties.endpoint?.let {
+            client.endpointOverride(URI.create(awsProperties.endpoint))
+        }
+
+        return client.build()
+    }
+
+    @Bean(destroyMethod = "close")
+    fun s3AsyncClient(): S3AsyncClient {
+        val client =
+            S3AsyncClient
                 .builder()
                 .credentialsProvider(credentialProvider())
                 .region(Region.of(awsProperties.region))

--- a/pida-clients/aws-client/src/main/kotlin/com/pida/client/aws/image/ImageS3Processor.kt
+++ b/pida-clients/aws-client/src/main/kotlin/com/pida/client/aws/image/ImageS3Processor.kt
@@ -93,13 +93,24 @@ class ImageS3Processor(
     ): S3ImageInfo? {
         val imageFilePath = imageFileConstructor.imageFilePath(prefix, prefixId)
 
-        return awsS3AsyncClient
-            .listObjects(
+        return awsS3Client
+            .getBucketListObjects(
                 bucketName = awsProperties.s3.bucket,
                 filePath = imageFilePath,
-            ).filterNot { it.key().endsWith("/") }
+            ).contents()
+            .orEmpty()
+            .asSequence()
+            .filterNot { it.key().endsWith("/") }
             .maxByOrNull(S3Object::lastModified)
             ?.toImageInfo(imageFilePath, Duration.ofSeconds(30))
+
+//        return awsS3AsyncClient
+//            .listObjects(
+//                bucketName = awsProperties.s3.bucket,
+//                filePath = imageFilePath,
+//            ).filterNot { it.key().endsWith("/") }
+//            .maxByOrNull(S3Object::lastModified)
+//            ?.toImageInfo(imageFilePath, Duration.ofSeconds(30))
     }
 
     private fun generateGetUrl(

--- a/pida-clients/aws-client/src/main/kotlin/com/pida/client/aws/image/ImageS3Processor.kt
+++ b/pida-clients/aws-client/src/main/kotlin/com/pida/client/aws/image/ImageS3Processor.kt
@@ -1,6 +1,7 @@
 package com.pida.client.aws.image
 
 import com.pida.client.aws.config.AwsProperties
+import com.pida.client.aws.s3.AwsS3AsyncClient
 import com.pida.client.aws.s3.AwsS3Client
 import com.pida.support.aws.ImageS3Caller
 import com.pida.support.aws.PresignedUrlRateLimiter
@@ -16,6 +17,7 @@ import java.time.ZoneId
 @Component
 class ImageS3Processor(
     private val awsS3Client: AwsS3Client,
+    private val awsS3AsyncClient: AwsS3AsyncClient,
     private val awsProperties: AwsProperties,
     private val imageFileConstructor: ImageFileConstructor,
     private val rateLimiter: PresignedUrlRateLimiter,
@@ -91,7 +93,11 @@ class ImageS3Processor(
     ): S3ImageInfo? {
         val imageFilePath = imageFileConstructor.imageFilePath(prefix, prefixId)
 
-        return listImageObjects(imageFilePath)
+        return awsS3AsyncClient
+            .listObjects(
+                bucketName = awsProperties.s3.bucket,
+                filePath = imageFilePath,
+            ).filterNot { it.key().endsWith("/") }
             .maxByOrNull(S3Object::lastModified)
             ?.toImageInfo(imageFilePath, Duration.ofSeconds(30))
     }

--- a/pida-clients/aws-client/src/main/kotlin/com/pida/client/aws/image/ImageS3Processor.kt
+++ b/pida-clients/aws-client/src/main/kotlin/com/pida/client/aws/image/ImageS3Processor.kt
@@ -93,24 +93,13 @@ class ImageS3Processor(
     ): S3ImageInfo? {
         val imageFilePath = imageFileConstructor.imageFilePath(prefix, prefixId)
 
-        return awsS3Client
-            .getBucketListObjects(
+        return awsS3AsyncClient
+            .listObjects(
                 bucketName = awsProperties.s3.bucket,
                 filePath = imageFilePath,
-            ).contents()
-            .orEmpty()
-            .asSequence()
-            .filterNot { it.key().endsWith("/") }
+            ).filterNot { it.key().endsWith("/") }
             .maxByOrNull(S3Object::lastModified)
             ?.toImageInfo(imageFilePath, Duration.ofSeconds(30))
-
-//        return awsS3AsyncClient
-//            .listObjects(
-//                bucketName = awsProperties.s3.bucket,
-//                filePath = imageFilePath,
-//            ).filterNot { it.key().endsWith("/") }
-//            .maxByOrNull(S3Object::lastModified)
-//            ?.toImageInfo(imageFilePath, Duration.ofSeconds(30))
     }
 
     private fun generateGetUrl(

--- a/pida-clients/aws-client/src/main/kotlin/com/pida/client/aws/image/ImageS3Processor.kt
+++ b/pida-clients/aws-client/src/main/kotlin/com/pida/client/aws/image/ImageS3Processor.kt
@@ -44,9 +44,11 @@ class ImageS3Processor(
                 Duration.ofSeconds(30), // 만료 시간 최소화
             )
 
+        val s3Key = "$imageFilePath/$imageFileName"
         return S3ImageUrl(
             presignedUrl,
             generateGetUrl(imageFilePath, imageFileName),
+            s3Key,
         )
     }
 
@@ -100,6 +102,12 @@ class ImageS3Processor(
             ).filterNot { it.key().endsWith("/") }
             .maxByOrNull(S3Object::lastModified)
             ?.toImageInfo(imageFilePath, Duration.ofSeconds(30))
+    }
+
+    override fun generatePresignedUrl(s3Key: String): String {
+        val filePath = s3Key.substringBeforeLast("/")
+        val fileName = s3Key.substringAfterLast("/")
+        return generateGetUrl(filePath, fileName)
     }
 
     private fun generateGetUrl(

--- a/pida-clients/aws-client/src/main/kotlin/com/pida/client/aws/s3/AwsS3AsyncClient.kt
+++ b/pida-clients/aws-client/src/main/kotlin/com/pida/client/aws/s3/AwsS3AsyncClient.kt
@@ -1,0 +1,37 @@
+package com.pida.client.aws.s3
+
+import kotlinx.coroutines.future.await
+import org.springframework.stereotype.Component
+import software.amazon.awssdk.services.s3.S3AsyncClient
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request
+import software.amazon.awssdk.services.s3.model.S3Object
+
+@Component
+class AwsS3AsyncClient(
+    private val s3AsyncClient: S3AsyncClient,
+) {
+    suspend fun listObjects(
+        bucketName: String,
+        filePath: String,
+    ): List<S3Object> {
+        val allObjects = mutableListOf<S3Object>()
+        var continuationToken: String? = null
+
+        do {
+            val request =
+                ListObjectsV2Request
+                    .builder()
+                    .bucket(bucketName)
+                    .prefix(filePath)
+                    .maxKeys(1000)
+                    .continuationToken(continuationToken)
+                    .build()
+
+            val response = s3AsyncClient.listObjectsV2(request).await()
+            allObjects.addAll(response.contents())
+            continuationToken = response.nextContinuationToken()
+        } while (response.isTruncated)
+
+        return allObjects
+    }
+}

--- a/pida-core/core-domain/src/main/kotlin/com/pida/blooming/BloomingFacade.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/blooming/BloomingFacade.kt
@@ -1,5 +1,6 @@
 package com.pida.blooming
 
+import com.pida.flowerspot.FlowerSpotService
 import com.pida.reporter.RecentReporterService
 import com.pida.support.aws.ImagePrefix
 import com.pida.support.aws.ImageS3Caller
@@ -20,6 +21,7 @@ class BloomingFacade(
     private val userService: UserService,
     private val imageS3Caller: ImageS3Caller,
     private val eventPublisher: ApplicationEventPublisher,
+    private val flowerSpotService: FlowerSpotService,
 ) {
     suspend fun readBloomingDetailsBySpotId(flowerSpotId: Long): BloomingDetails =
         coroutineScope {
@@ -107,9 +109,19 @@ class BloomingFacade(
                 is NewBlooming.FlowerEvent -> ImagePrefix.FLOWEREVENT.value to newBlooming.flowerEventId
             }
 
-        return BloomingImageUploadUrl.from(
-            imageS3Caller.createUploadUrl(newBlooming.userId, prefix, prefixId),
-        )
+        val imageUploadUrl = imageS3Caller.createUploadUrl(newBlooming.userId, prefix, prefixId)
+
+        when (newBlooming) {
+            is NewBlooming.FlowerSpot -> {
+                flowerSpotService.updatePreviewImageKey(
+                    newBlooming.flowerSpotId,
+                    imageUploadUrl.s3Key,
+                )
+            }
+            is NewBlooming.FlowerEvent -> {}
+        }
+
+        return BloomingImageUploadUrl.from(imageUploadUrl)
     }
 
     private fun buildBloomingDetails(

--- a/pida-core/core-domain/src/main/kotlin/com/pida/flowerspot/FlowerSpot.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/flowerspot/FlowerSpot.kt
@@ -16,4 +16,6 @@ data class FlowerSpot(
     val kind: FlowerKind,
     val type: FlowerSpotType,
     val deletedAt: LocalDateTime?,
+    val previewImageKey: String? = null,
+    val previewImageUploadedAt: LocalDateTime? = null,
 )

--- a/pida-core/core-domain/src/main/kotlin/com/pida/flowerspot/FlowerSpotFacade.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/flowerspot/FlowerSpotFacade.kt
@@ -1,12 +1,9 @@
 package com.pida.flowerspot
 
-import com.fasterxml.jackson.core.type.TypeReference
 import com.pida.blooming.BloomingService
 import com.pida.support.aws.ImagePrefix
 import com.pida.support.aws.ImageS3Caller
 import com.pida.support.aws.S3ImageInfo
-import com.pida.support.cache.Cache
-import com.pida.support.extension.logger
 import com.pida.support.geo.Region
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
@@ -18,13 +15,6 @@ class FlowerSpotFacade(
     private val bloomingService: BloomingService,
     private val imageS3Caller: ImageS3Caller,
 ) {
-    companion object {
-        const val PREVIEW_IMAGE_KEY = "spot:preview"
-        const val PREVIEW_IMAGE_TTL = 10L
-    }
-
-    private val logger by logger()
-
     suspend fun readFlowerSpotDetails(spotId: Long): FlowerSpotDetails =
         coroutineScope {
             val flowerSpotDeferred = async { flowerSpotService.readOneFlowerSpot(spotId) }
@@ -53,42 +43,24 @@ class FlowerSpotFacade(
             val flowerSpots = flowerSpotService.readAllFlowerSpot(region, location)
             if (flowerSpots.isEmpty()) return@coroutineScope emptyList()
 
-            val bloomingDeferred = async { bloomingService.recentlyBloomingBySpotIds(flowerSpots.map { it.id }) }
-
-            val s3Start = System.currentTimeMillis()
-            val previewDeferred =
-                flowerSpots.map { spot ->
-                    async {
-                        spot.id to
-                            imageS3Caller.getPreviewImage(
-                                prefix = ImagePrefix.FLOWERSPOT.value,
-                                prefixId = spot.id,
-                            )
-                    }
-                }
-
-            val previewBySpotId = previewDeferred.associate { it.await() }
-            logger.info("s3 preview fetch time ${System.currentTimeMillis() - s3Start}ms (${flowerSpots.size} spots)")
-            val bloomingBySpotId = bloomingDeferred.await().groupBy { it.flowerSpotId }
+            val bloomingBySpotId =
+                bloomingService
+                    .recentlyBloomingBySpotIds(flowerSpots.map { it.id })
+                    .groupBy { it.flowerSpotId }
 
             flowerSpots.map { flowerSpot ->
+                val previewImage =
+                    flowerSpot.previewImageKey?.let { key ->
+                        S3ImageInfo(
+                            url = imageS3Caller.generatePresignedUrl(key),
+                            uploadedAt = flowerSpot.previewImageUploadedAt!!,
+                        )
+                    }
                 FlowerSpotDetails.of(
                     flowerSpot = flowerSpot,
                     bloomings = bloomingBySpotId[flowerSpot.id] ?: emptyList(),
-                    images = listOfNotNull(previewBySpotId[flowerSpot.id]),
+                    images = listOfNotNull(previewImage),
                 )
             }
-        }
-
-    private suspend fun cachedPreviewImage(spotId: Long): S3ImageInfo? =
-        Cache.cache(
-            ttl = PREVIEW_IMAGE_TTL,
-            key = "$PREVIEW_IMAGE_KEY:$spotId",
-            typeReference = object : TypeReference<S3ImageInfo?>() {},
-        ) {
-            imageS3Caller.getPreviewImage(
-                prefix = ImagePrefix.FLOWERSPOT.value,
-                prefixId = spotId,
-            )
         }
 }

--- a/pida-core/core-domain/src/main/kotlin/com/pida/flowerspot/FlowerSpotFacade.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/flowerspot/FlowerSpotFacade.kt
@@ -1,8 +1,11 @@
 package com.pida.flowerspot
 
+import com.fasterxml.jackson.core.type.TypeReference
 import com.pida.blooming.BloomingService
 import com.pida.support.aws.ImagePrefix
 import com.pida.support.aws.ImageS3Caller
+import com.pida.support.aws.S3ImageInfo
+import com.pida.support.cache.Cache
 import com.pida.support.extension.logger
 import com.pida.support.geo.Region
 import kotlinx.coroutines.async
@@ -60,11 +63,7 @@ class FlowerSpotFacade(
             val previewDeferred =
                 flowerSpots.map { spot ->
                     async {
-                        spot.id to
-                            imageS3Caller.getPreviewImage(
-                                prefix = ImagePrefix.FLOWERSPOT.value,
-                                prefixId = spot.id,
-                            )
+                        spot.id to cachedPreviewImage(spot.id)
                     }
                 }
             logger.info("previewDeferred querying time ${System.currentTimeMillis() - point3}ms")
@@ -83,15 +82,15 @@ class FlowerSpotFacade(
             }
         }
 
-//    private suspend fun cachedPreviewImage(spotId: Long): S3ImageInfo? =
-//        Cache.cache(
-//            ttl = PREVIEW_IMAGE_TTL,
-//            key = "$PREVIEW_IMAGE_KEY:$spotId",
-//            typeReference = object : TypeReference<S3ImageInfo?>() {},
-//        ) {
-//            imageS3Caller.getPreviewImage(
-//                prefix = ImagePrefix.FLOWERSPOT.value,
-//                prefixId = spotId,
-//            )
-//        }
+    private suspend fun cachedPreviewImage(spotId: Long): S3ImageInfo? =
+        Cache.cache(
+            ttl = PREVIEW_IMAGE_TTL,
+            key = "$PREVIEW_IMAGE_KEY:$spotId",
+            typeReference = object : TypeReference<S3ImageInfo?>() {},
+        ) {
+            imageS3Caller.getPreviewImage(
+                prefix = ImagePrefix.FLOWERSPOT.value,
+                prefixId = spotId,
+            )
+        }
 }

--- a/pida-core/core-domain/src/main/kotlin/com/pida/flowerspot/FlowerSpotFacade.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/flowerspot/FlowerSpotFacade.kt
@@ -50,28 +50,22 @@ class FlowerSpotFacade(
         location: FlowerSpotLocation,
     ): List<FlowerSpotDetails> =
         coroutineScope {
-            val point1 = System.currentTimeMillis()
             val flowerSpots = flowerSpotService.readAllFlowerSpot(region, location)
-            logger.info("flowerSpots querying time ${System.currentTimeMillis() - point1}ms")
             if (flowerSpots.isEmpty()) return@coroutineScope emptyList()
 
-            val point2 = System.currentTimeMillis()
             val bloomingDeferred = async { bloomingService.recentlyBloomingBySpotIds(flowerSpots.map { it.id }) }
-            logger.info("bloomingDeferred querying time ${System.currentTimeMillis() - point2}ms")
 
-            val point3 = System.currentTimeMillis()
+            val s3Start = System.currentTimeMillis()
             val previewDeferred =
                 flowerSpots.map { spot ->
                     async {
                         spot.id to cachedPreviewImage(spot.id)
                     }
                 }
-            logger.info("previewDeferred querying time ${System.currentTimeMillis() - point3}ms")
 
-            val point4 = System.currentTimeMillis()
-            val bloomingBySpotId = bloomingDeferred.await().groupBy { it.flowerSpotId }
             val previewBySpotId = previewDeferred.associate { it.await() }
-            logger.info("grouping time ${System.currentTimeMillis() - point4}ms")
+            logger.info("s3 preview fetch time ${System.currentTimeMillis() - s3Start}ms (${flowerSpots.size} spots)")
+            val bloomingBySpotId = bloomingDeferred.await().groupBy { it.flowerSpotId }
 
             flowerSpots.map { flowerSpot ->
                 FlowerSpotDetails.of(

--- a/pida-core/core-domain/src/main/kotlin/com/pida/flowerspot/FlowerSpotFacade.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/flowerspot/FlowerSpotFacade.kt
@@ -59,7 +59,11 @@ class FlowerSpotFacade(
             val previewDeferred =
                 flowerSpots.map { spot ->
                     async {
-                        spot.id to cachedPreviewImage(spot.id)
+                        spot.id to
+                            imageS3Caller.getPreviewImage(
+                                prefix = ImagePrefix.FLOWERSPOT.value,
+                                prefixId = spot.id,
+                            )
                     }
                 }
 

--- a/pida-core/core-domain/src/main/kotlin/com/pida/flowerspot/FlowerSpotFacade.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/flowerspot/FlowerSpotFacade.kt
@@ -4,7 +4,6 @@ import com.pida.blooming.BloomingService
 import com.pida.support.aws.ImagePrefix
 import com.pida.support.aws.ImageS3Caller
 import com.pida.support.aws.S3ImageInfo
-import com.pida.support.extension.logger
 import com.pida.support.geo.Region
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
@@ -16,8 +15,6 @@ class FlowerSpotFacade(
     private val bloomingService: BloomingService,
     private val imageS3Caller: ImageS3Caller,
 ) {
-    private val logger by logger()
-
     suspend fun readFlowerSpotDetails(spotId: Long): FlowerSpotDetails =
         coroutineScope {
             val flowerSpotDeferred = async { flowerSpotService.readOneFlowerSpot(spotId) }
@@ -43,37 +40,28 @@ class FlowerSpotFacade(
         location: FlowerSpotLocation,
     ): List<FlowerSpotDetails> =
         coroutineScope {
-            val t0 = System.currentTimeMillis()
             val flowerSpots = flowerSpotService.readAllFlowerSpot(region, location)
-            logger.info("flowerSpot query: ${System.currentTimeMillis() - t0}ms (${flowerSpots.size} spots)")
             if (flowerSpots.isEmpty()) return@coroutineScope emptyList()
 
-            val t1 = System.currentTimeMillis()
             val bloomingBySpotId =
                 bloomingService
                     .recentlyBloomingBySpotIds(flowerSpots.map { it.id })
                     .groupBy { it.flowerSpotId }
-            logger.info("blooming query: ${System.currentTimeMillis() - t1}ms")
 
-            val t2 = System.currentTimeMillis()
-            val result =
-                flowerSpots.map { flowerSpot ->
-                    val previewImage =
-                        flowerSpot.previewImageKey?.let { key ->
-                            S3ImageInfo(
-                                url = imageS3Caller.generatePresignedUrl(key),
-                                uploadedAt = flowerSpot.previewImageUploadedAt!!,
-                            )
-                        }
-                    FlowerSpotDetails.of(
-                        flowerSpot = flowerSpot,
-                        bloomings = bloomingBySpotId[flowerSpot.id] ?: emptyList(),
-                        images = listOfNotNull(previewImage),
-                    )
-                }
-            logger.info("presigned url generation: ${System.currentTimeMillis() - t2}ms")
-            logger.info("total: ${System.currentTimeMillis() - t0}ms")
+            flowerSpots.map { flowerSpot ->
+                FlowerSpotDetails.of(
+                    flowerSpot = flowerSpot,
+                    bloomings = bloomingBySpotId[flowerSpot.id] ?: emptyList(),
+                    images = listOfNotNull(previewImagePresignedUrl(flowerSpot)),
+                )
+            }
+        }
 
-            result
+    private fun previewImagePresignedUrl(flowerSpot: FlowerSpot): S3ImageInfo? =
+        flowerSpot.previewImageKey?.let { key ->
+            S3ImageInfo(
+                url = imageS3Caller.generatePresignedUrl(key),
+                uploadedAt = flowerSpot.previewImageUploadedAt!!,
+            )
         }
 }

--- a/pida-core/core-domain/src/main/kotlin/com/pida/flowerspot/FlowerSpotFacade.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/flowerspot/FlowerSpotFacade.kt
@@ -4,6 +4,7 @@ import com.pida.blooming.BloomingService
 import com.pida.support.aws.ImagePrefix
 import com.pida.support.aws.ImageS3Caller
 import com.pida.support.aws.S3ImageInfo
+import com.pida.support.extension.logger
 import com.pida.support.geo.Region
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
@@ -15,6 +16,8 @@ class FlowerSpotFacade(
     private val bloomingService: BloomingService,
     private val imageS3Caller: ImageS3Caller,
 ) {
+    private val logger by logger()
+
     suspend fun readFlowerSpotDetails(spotId: Long): FlowerSpotDetails =
         coroutineScope {
             val flowerSpotDeferred = async { flowerSpotService.readOneFlowerSpot(spotId) }
@@ -40,27 +43,37 @@ class FlowerSpotFacade(
         location: FlowerSpotLocation,
     ): List<FlowerSpotDetails> =
         coroutineScope {
+            val t0 = System.currentTimeMillis()
             val flowerSpots = flowerSpotService.readAllFlowerSpot(region, location)
+            logger.info("flowerSpot query: ${System.currentTimeMillis() - t0}ms (${flowerSpots.size} spots)")
             if (flowerSpots.isEmpty()) return@coroutineScope emptyList()
 
+            val t1 = System.currentTimeMillis()
             val bloomingBySpotId =
                 bloomingService
                     .recentlyBloomingBySpotIds(flowerSpots.map { it.id })
                     .groupBy { it.flowerSpotId }
+            logger.info("blooming query: ${System.currentTimeMillis() - t1}ms")
 
-            flowerSpots.map { flowerSpot ->
-                val previewImage =
-                    flowerSpot.previewImageKey?.let { key ->
-                        S3ImageInfo(
-                            url = imageS3Caller.generatePresignedUrl(key),
-                            uploadedAt = flowerSpot.previewImageUploadedAt!!,
-                        )
-                    }
-                FlowerSpotDetails.of(
-                    flowerSpot = flowerSpot,
-                    bloomings = bloomingBySpotId[flowerSpot.id] ?: emptyList(),
-                    images = listOfNotNull(previewImage),
-                )
-            }
+            val t2 = System.currentTimeMillis()
+            val result =
+                flowerSpots.map { flowerSpot ->
+                    val previewImage =
+                        flowerSpot.previewImageKey?.let { key ->
+                            S3ImageInfo(
+                                url = imageS3Caller.generatePresignedUrl(key),
+                                uploadedAt = flowerSpot.previewImageUploadedAt!!,
+                            )
+                        }
+                    FlowerSpotDetails.of(
+                        flowerSpot = flowerSpot,
+                        bloomings = bloomingBySpotId[flowerSpot.id] ?: emptyList(),
+                        images = listOfNotNull(previewImage),
+                    )
+                }
+            logger.info("presigned url generation: ${System.currentTimeMillis() - t2}ms")
+            logger.info("total: ${System.currentTimeMillis() - t0}ms")
+
+            result
         }
 }

--- a/pida-core/core-domain/src/main/kotlin/com/pida/flowerspot/FlowerSpotFacade.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/flowerspot/FlowerSpotFacade.kt
@@ -47,12 +47,16 @@ class FlowerSpotFacade(
         location: FlowerSpotLocation,
     ): List<FlowerSpotDetails> =
         coroutineScope {
+            val point1 = System.currentTimeMillis()
             val flowerSpots = flowerSpotService.readAllFlowerSpot(region, location)
+            logger.info("flowerSpots querying time ${System.currentTimeMillis() - point1}ms")
             if (flowerSpots.isEmpty()) return@coroutineScope emptyList()
 
+            val point2 = System.currentTimeMillis()
             val bloomingDeferred = async { bloomingService.recentlyBloomingBySpotIds(flowerSpots.map { it.id }) }
+            logger.info("bloomingDeferred querying time ${System.currentTimeMillis() - point2}ms")
 
-            val startTime = System.currentTimeMillis()
+            val point3 = System.currentTimeMillis()
             val previewDeferred =
                 flowerSpots.map { spot ->
                     async {
@@ -63,10 +67,12 @@ class FlowerSpotFacade(
                             )
                     }
                 }
-            logger.info("Preview image fetch initiated for ${flowerSpots.size} spots in ${System.currentTimeMillis() - startTime}ms")
+            logger.info("previewDeferred querying time ${System.currentTimeMillis() - point3}ms")
 
+            val point4 = System.currentTimeMillis()
             val bloomingBySpotId = bloomingDeferred.await().groupBy { it.flowerSpotId }
             val previewBySpotId = previewDeferred.associate { it.await() }
+            logger.info("grouping time ${System.currentTimeMillis() - point4}ms")
 
             flowerSpots.map { flowerSpot ->
                 FlowerSpotDetails.of(

--- a/pida-core/core-domain/src/main/kotlin/com/pida/flowerspot/FlowerSpotFacade.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/flowerspot/FlowerSpotFacade.kt
@@ -1,11 +1,9 @@
 package com.pida.flowerspot
 
-import com.fasterxml.jackson.core.type.TypeReference
 import com.pida.blooming.BloomingService
 import com.pida.support.aws.ImagePrefix
 import com.pida.support.aws.ImageS3Caller
-import com.pida.support.aws.S3ImageInfo
-import com.pida.support.cache.Cache
+import com.pida.support.extension.logger
 import com.pida.support.geo.Region
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
@@ -21,6 +19,8 @@ class FlowerSpotFacade(
         const val PREVIEW_IMAGE_KEY = "spot:preview"
         const val PREVIEW_IMAGE_TTL = 10L
     }
+
+    private val logger by logger()
 
     suspend fun readFlowerSpotDetails(spotId: Long): FlowerSpotDetails =
         coroutineScope {
@@ -51,10 +51,19 @@ class FlowerSpotFacade(
             if (flowerSpots.isEmpty()) return@coroutineScope emptyList()
 
             val bloomingDeferred = async { bloomingService.recentlyBloomingBySpotIds(flowerSpots.map { it.id }) }
+
+            val startTime = System.currentTimeMillis()
             val previewDeferred =
                 flowerSpots.map { spot ->
-                    async { spot.id to cachedPreviewImage(spot.id) }
+                    async {
+                        spot.id to
+                            imageS3Caller.getPreviewImage(
+                                prefix = ImagePrefix.FLOWERSPOT.value,
+                                prefixId = spot.id,
+                            )
+                    }
                 }
+            logger.info("Preview image fetch initiated for ${flowerSpots.size} spots in ${System.currentTimeMillis() - startTime}ms")
 
             val bloomingBySpotId = bloomingDeferred.await().groupBy { it.flowerSpotId }
             val previewBySpotId = previewDeferred.associate { it.await() }
@@ -68,15 +77,15 @@ class FlowerSpotFacade(
             }
         }
 
-    private suspend fun cachedPreviewImage(spotId: Long): S3ImageInfo? =
-        Cache.cache(
-            ttl = PREVIEW_IMAGE_TTL,
-            key = "$PREVIEW_IMAGE_KEY:$spotId",
-            typeReference = object : TypeReference<S3ImageInfo?>() {},
-        ) {
-            imageS3Caller.getPreviewImage(
-                prefix = ImagePrefix.FLOWERSPOT.value,
-                prefixId = spotId,
-            )
-        }
+//    private suspend fun cachedPreviewImage(spotId: Long): S3ImageInfo? =
+//        Cache.cache(
+//            ttl = PREVIEW_IMAGE_TTL,
+//            key = "$PREVIEW_IMAGE_KEY:$spotId",
+//            typeReference = object : TypeReference<S3ImageInfo?>() {},
+//        ) {
+//            imageS3Caller.getPreviewImage(
+//                prefix = ImagePrefix.FLOWERSPOT.value,
+//                prefixId = spotId,
+//            )
+//        }
 }

--- a/pida-core/core-domain/src/main/kotlin/com/pida/flowerspot/FlowerSpotRepository.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/flowerspot/FlowerSpotRepository.kt
@@ -1,6 +1,7 @@
 package com.pida.flowerspot
 
 import com.pida.support.geo.Region
+import java.time.LocalDateTime
 
 interface FlowerSpotRepository {
     suspend fun findBy(spotId: Long): FlowerSpot
@@ -23,4 +24,10 @@ interface FlowerSpotRepository {
     ): List<FlowerSpot>
 
     fun findByStreetNameContaining(streetName: String): List<FlowerSpot>
+
+    suspend fun updatePreviewImageKey(
+        spotId: Long,
+        key: String,
+        uploadedAt: LocalDateTime,
+    )
 }

--- a/pida-core/core-domain/src/main/kotlin/com/pida/flowerspot/FlowerSpotService.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/flowerspot/FlowerSpotService.kt
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service
 @Service
 class FlowerSpotService(
     private val flowerSpotFinder: FlowerSpotFinder,
+    private val flowerSpotUpdater: FlowerSpotUpdater,
 ) {
     suspend fun readAllFlowerSpot(
         region: Region?,
@@ -29,4 +30,9 @@ class FlowerSpotService(
 
         return flowerSpotFinder.searchByStreetName(trimmed)
     }
+
+    suspend fun updatePreviewImageKey(
+        spotId: Long,
+        key: String,
+    ) = flowerSpotUpdater.updatePreviewImageKey(spotId, key)
 }

--- a/pida-core/core-domain/src/main/kotlin/com/pida/flowerspot/FlowerSpotUpdater.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/flowerspot/FlowerSpotUpdater.kt
@@ -1,0 +1,16 @@
+package com.pida.flowerspot
+
+import org.springframework.stereotype.Component
+import java.time.LocalDateTime
+
+@Component
+class FlowerSpotUpdater(
+    private val flowerSpotRepository: FlowerSpotRepository,
+) {
+    suspend fun updatePreviewImageKey(
+        spotId: Long,
+        key: String,
+    ) {
+        flowerSpotRepository.updatePreviewImageKey(spotId, key, LocalDateTime.now())
+    }
+}

--- a/pida-core/core-domain/src/main/kotlin/com/pida/support/aws/ImageS3Caller.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/support/aws/ImageS3Caller.kt
@@ -34,6 +34,13 @@ interface ImageS3Caller {
     ): S3ImageInfo?
 
     /**
+     * S3 key로부터 presigned GET URL 생성 (로컬 서명, 네트워크 호출 없음)
+     *
+     * @param s3Key [String] S3 객체 전체 키 (e.g. "prod/flowerspot/42/abcdef.jpeg")
+     */
+    fun generatePresignedUrl(s3Key: String): String
+
+    /**
      * 서버 사이드 이미지 업로드
      *
      * @param prefix [String] 도메인

--- a/pida-core/core-domain/src/main/kotlin/com/pida/support/aws/S3ImageUrl.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/support/aws/S3ImageUrl.kt
@@ -3,4 +3,5 @@ package com.pida.support.aws
 data class S3ImageUrl(
     val presignedUrl: String,
     val presignedGetUrl: String,
+    val s3Key: String,
 )

--- a/pida-core/core-domain/src/test/kotlin/com/pida/blooming/BloomingFacadeTest.kt
+++ b/pida-core/core-domain/src/test/kotlin/com/pida/blooming/BloomingFacadeTest.kt
@@ -1,5 +1,6 @@
 package com.pida.blooming
 
+import com.pida.flowerspot.FlowerSpotService
 import com.pida.reporter.RecentReporterService
 import com.pida.support.aws.ImagePrefix
 import com.pida.support.aws.ImageS3Caller
@@ -25,6 +26,7 @@ class BloomingFacadeTest {
             val userService = mockk<UserService>()
             val imageS3Caller = mockk<ImageS3Caller>()
             val eventPublisher = mockk<ApplicationEventPublisher>()
+            val flowerSpotService = mockk<FlowerSpotService>()
             val facade =
                 BloomingFacade(
                     bloomingService = bloomingService,
@@ -32,6 +34,7 @@ class BloomingFacadeTest {
                     userService = userService,
                     imageS3Caller = imageS3Caller,
                     eventPublisher = eventPublisher,
+                    flowerSpotService = flowerSpotService,
                 )
 
             coEvery { bloomingService.recentlyBloomingByEventId(7L) } returns
@@ -90,6 +93,7 @@ class BloomingFacadeTest {
             val userService = mockk<UserService>()
             val imageS3Caller = mockk<ImageS3Caller>()
             val eventPublisher = mockk<ApplicationEventPublisher>()
+            val flowerSpotService = mockk<FlowerSpotService>()
             val facade =
                 BloomingFacade(
                     bloomingService = bloomingService,
@@ -97,6 +101,7 @@ class BloomingFacadeTest {
                     userService = userService,
                     imageS3Caller = imageS3Caller,
                     eventPublisher = eventPublisher,
+                    flowerSpotService = flowerSpotService,
                 )
             val newBlooming =
                 NewBlooming.FlowerSpot(
@@ -121,7 +126,9 @@ class BloomingFacadeTest {
                 S3ImageUrl(
                     presignedUrl = "spot-upload",
                     presignedGetUrl = "spot-preview",
+                    s3Key = "prod/flowerspot/3/abc.jpeg",
                 )
+            coEvery { flowerSpotService.updatePreviewImageKey(3L, "prod/flowerspot/3/abc.jpeg") } returns Unit
 
             val result = facade.uploadBloomingStatus(newBlooming)
 
@@ -140,6 +147,7 @@ class BloomingFacadeTest {
             val userService = mockk<UserService>()
             val imageS3Caller = mockk<ImageS3Caller>()
             val eventPublisher = mockk<ApplicationEventPublisher>()
+            val flowerSpotService = mockk<FlowerSpotService>()
             val facade =
                 BloomingFacade(
                     bloomingService = bloomingService,
@@ -147,6 +155,7 @@ class BloomingFacadeTest {
                     userService = userService,
                     imageS3Caller = imageS3Caller,
                     eventPublisher = eventPublisher,
+                    flowerSpotService = flowerSpotService,
                 )
             val newBlooming =
                 NewBlooming.FlowerEvent(
@@ -171,6 +180,7 @@ class BloomingFacadeTest {
                 S3ImageUrl(
                     presignedUrl = "event-upload",
                     presignedGetUrl = "event-preview",
+                    s3Key = "prod/flowerevent/7/abc.jpeg",
                 )
 
             val result = facade.uploadBloomingStatus(newBlooming)

--- a/pida-core/core-domain/src/test/kotlin/com/pida/flowerspot/FlowerSpotFacadeTest.kt
+++ b/pida-core/core-domain/src/test/kotlin/com/pida/flowerspot/FlowerSpotFacadeTest.kt
@@ -6,9 +6,7 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.pida.blooming.Blooming
 import com.pida.blooming.BloomingService
 import com.pida.blooming.BloomingStatus
-import com.pida.support.aws.ImagePrefix
 import com.pida.support.aws.ImageS3Caller
-import com.pida.support.aws.S3ImageInfo
 import com.pida.support.cache.Cache
 import com.pida.support.cache.CacheAdvice
 import com.pida.support.cache.CacheRepository
@@ -35,7 +33,9 @@ class FlowerSpotFacadeTest {
             Cache(CacheAdvice(inMemoryCacheRepository(), cacheObjectMapper()))
             val facade = FlowerSpotFacade(flowerSpotService, bloomingService, imageS3Caller)
             val location = FlowerSpotLocation(swLat = null, swLng = null, neLat = null, neLng = null)
-            val firstSpot = flowerSpot(id = 10L, streetName = "첫 번째 거리")
+            val previewKey = "prod/flowerspot/10/abc.jpeg"
+            val previewUploadedAt = LocalDateTime.of(2026, 3, 20, 12, 0)
+            val firstSpot = flowerSpot(id = 10L, streetName = "첫 번째 거리", previewImageKey = previewKey, previewImageUploadedAt = previewUploadedAt)
             val secondSpot = flowerSpot(id = 20L, streetName = "두 번째 거리")
 
             coEvery { flowerSpotService.readAllFlowerSpot(region = null, location = location) } returns listOf(firstSpot, secondSpot)
@@ -66,12 +66,7 @@ class FlowerSpotFacadeTest {
                         createdAt = LocalDateTime.of(2026, 3, 20, 9, 0),
                     ),
                 )
-            coEvery { imageS3Caller.getPreviewImage(ImagePrefix.FLOWERSPOT.value, 10L) } returns
-                S3ImageInfo(
-                    url = "https://cdn.example.com/flower-spot-10-preview.jpg",
-                    uploadedAt = LocalDateTime.of(2026, 3, 20, 12, 0),
-                )
-            coEvery { imageS3Caller.getPreviewImage(ImagePrefix.FLOWERSPOT.value, 20L) } returns null
+            every { imageS3Caller.generatePresignedUrl(previewKey) } returns "https://cdn.example.com/flower-spot-10-preview.jpg"
 
             val result = facade.findAllFlowerSpot(region = null, location = location)
 
@@ -83,8 +78,8 @@ class FlowerSpotFacadeTest {
             result.last().bloomingStatus shouldBe BloomingStatus.LITTLE
             result.last().images shouldBe emptyList()
 
-            coVerify(exactly = 1) { imageS3Caller.getPreviewImage(ImagePrefix.FLOWERSPOT.value, 10L) }
-            coVerify(exactly = 1) { imageS3Caller.getPreviewImage(ImagePrefix.FLOWERSPOT.value, 20L) }
+            verify(exactly = 1) { imageS3Caller.generatePresignedUrl(previewKey) }
+            coVerify(exactly = 0) { imageS3Caller.getPreviewImage(any(), any()) }
             coVerify(exactly = 0) { imageS3Caller.getImageUrl(any(), any(), any()) }
         }
 
@@ -111,6 +106,8 @@ class FlowerSpotFacadeTest {
     private fun flowerSpot(
         id: Long,
         streetName: String,
+        previewImageKey: String? = null,
+        previewImageUploadedAt: LocalDateTime? = null,
     ) = FlowerSpot(
         id = id,
         address = "서울특별시 강남구",
@@ -123,6 +120,8 @@ class FlowerSpotFacadeTest {
         kind = FlowerKind.BLOSSOM,
         type = FlowerSpotType.WALKING_TRAIL,
         deletedAt = null,
+        previewImageKey = previewImageKey,
+        previewImageUploadedAt = previewImageUploadedAt,
     )
 
     private fun inMemoryCacheRepository(): CacheRepository =

--- a/pida-storage/db-core/src/main/kotlin/com/pida/storage/db/core/flowerspot/FlowerSpotCoreRepository.kt
+++ b/pida-storage/db-core/src/main/kotlin/com/pida/storage/db/core/flowerspot/FlowerSpotCoreRepository.kt
@@ -8,6 +8,7 @@ import com.pida.support.geo.Region
 import com.pida.support.tx.TransactionTemplates
 import com.pida.support.tx.coExecute
 import org.springframework.stereotype.Repository
+import java.time.LocalDateTime
 
 @Repository
 class FlowerSpotCoreRepository(
@@ -76,4 +77,13 @@ class FlowerSpotCoreRepository(
         flowerSpotJpaRepository
             .findByStreetNameContainingAndDeletedAtIsNull(streetName)
             .map { it.toFlowerSpot() }
+
+    override suspend fun updatePreviewImageKey(
+        spotId: Long,
+        key: String,
+        uploadedAt: LocalDateTime,
+    ) = tx.writer.coExecute {
+        val entity = flowerSpotJpaRepository.findByIdAndDeletedAtIsNullOrElseThrow(spotId)
+        entity.updatePreviewImage(key, uploadedAt)
+    }
 }

--- a/pida-storage/db-core/src/main/kotlin/com/pida/storage/db/core/flowerspot/FlowerSpotEntity.kt
+++ b/pida-storage/db-core/src/main/kotlin/com/pida/storage/db/core/flowerspot/FlowerSpotEntity.kt
@@ -14,6 +14,7 @@ import jakarta.persistence.Index
 import jakarta.persistence.Table
 import org.locationtech.jts.geom.LineString
 import org.locationtech.jts.geom.Point
+import java.time.LocalDateTime
 
 @Entity
 @Table(
@@ -41,6 +42,9 @@ class FlowerSpotEntity(
     @Column(columnDefinition = "varchar(30)")
     val type: FlowerSpotType,
 ) : BaseEntity() {
+    var previewImageKey: String? = null
+    var previewImageUploadedAt: LocalDateTime? = null
+
     fun toFlowerSpot(): FlowerSpot =
         FlowerSpot(
             id = id!!,
@@ -54,5 +58,15 @@ class FlowerSpotEntity(
             kind = kind,
             type = type,
             deletedAt = deletedAt,
+            previewImageKey = previewImageKey,
+            previewImageUploadedAt = previewImageUploadedAt,
         )
+
+    fun updatePreviewImage(
+        key: String,
+        uploadedAt: LocalDateTime,
+    ) {
+        this.previewImageKey = key
+        this.previewImageUploadedAt = uploadedAt
+    }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #134 

## 📌 작업 내용 및 특이 사항

- S3AsyncClient 도입으로 코루틴 스코프 내 논블로킹 IO 요청 병렬 처리 구현
- 개화 상태 업로드 시 preview 이미지 key를 캐싱하고 해당 key 기반으로 presignedUrl 생성

## 📝 참고

- `GET /api/v1/flower-spot` 4000ms --> 500ms 대로 조회 성능 대폭 개선 (캐시히트 시)

## 📌 체크 리스트
<!-- 
    조건을 만족하셨다면 공백 대신 x 를 넣어주세요.
    ex:
    - [x] ~~
    - [ ] ~~
-->
- [ ] 리뷰어를 추가하셨나요 ?
- [ ] 변경사항에 대해 충분히 설명하고 있나요 ?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Async S3 listing and direct presigned-image URL generation by object key.
  * Preview-image metadata (key + uploaded timestamp) persisted and updatable on spot uploads.
* **Behavioral Changes**
  * Preview URLs now derived from stored keys (removed per-spot cached lookup).
* **Chores**
  * Enabled Kotlin coroutines for runtime async support.
* **Tests**
  * Tests adjusted for preview-key handling and new presigned-URL shape.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->