### PR TITLE
[Fix] Remove Blooming Cache

### DIFF
--- a/pida-core/core-domain/src/main/kotlin/com/pida/blooming/BloomingFinder.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/blooming/BloomingFinder.kt
@@ -31,11 +31,11 @@ class BloomingFinder(
 
     suspend fun readRecentlyBloomingByCafeId(cafeId: Long): List<Blooming> = bloomingRepository.findRecentlyByCafeId(cafeId)
 
-    fun recentlyBloomingBySpotIds(spotIds: List<Long>): List<Blooming> = bloomingRepository.findRecentBySpotIds(spotIds)
+    suspend fun recentlyBloomingBySpotIds(spotIds: List<Long>): List<Blooming> = bloomingRepository.findRecentBySpotIds(spotIds)
 
-    fun recentlyBloomingByEventIds(eventIds: List<Long>): List<Blooming> = bloomingRepository.findRecentByEventIds(eventIds)
+    suspend fun recentlyBloomingByEventIds(eventIds: List<Long>): List<Blooming> = bloomingRepository.findRecentByEventIds(eventIds)
 
-    fun recentlyBloomingByCafeIds(cafeIds: List<Long>): List<Blooming> = bloomingRepository.findRecentByCafeIds(cafeIds)
+    suspend fun recentlyBloomingByCafeIds(cafeIds: List<Long>): List<Blooming> = bloomingRepository.findRecentByCafeIds(cafeIds)
 
     fun readTodayBloomingByUserId(
         userId: Long,

--- a/pida-core/core-domain/src/main/kotlin/com/pida/blooming/BloomingRepository.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/blooming/BloomingRepository.kt
@@ -31,11 +31,11 @@ interface BloomingRepository {
 
     suspend fun findRecentlyByCafeId(cafeId: Long): List<Blooming>
 
-    fun findRecentBySpotIds(spotIds: List<Long>): List<Blooming>
+    suspend fun findRecentBySpotIds(spotIds: List<Long>): List<Blooming>
 
-    fun findRecentByEventIds(eventIds: List<Long>): List<Blooming>
+    suspend fun findRecentByEventIds(eventIds: List<Long>): List<Blooming>
 
-    fun findRecentByCafeIds(cafeIds: List<Long>): List<Blooming>
+    suspend fun findRecentByCafeIds(cafeIds: List<Long>): List<Blooming>
 
     fun findTodayBloomingByUserId(
         userId: Long,

--- a/pida-core/core-domain/src/main/kotlin/com/pida/blooming/BloomingService.kt
+++ b/pida-core/core-domain/src/main/kotlin/com/pida/blooming/BloomingService.kt
@@ -1,8 +1,5 @@
 package com.pida.blooming
 
-import com.fasterxml.jackson.core.type.TypeReference
-import com.pida.support.cache.Cache
-import com.pida.support.cache.CacheRepository
 import com.pida.support.error.ErrorException
 import com.pida.support.error.ErrorType
 import org.springframework.stereotype.Service
@@ -12,15 +9,7 @@ class BloomingService(
     private val bloomingAppender: BloomingAppender,
     private val bloomingValidator: BloomingValidator,
     private val bloomingFinder: BloomingFinder,
-    private val cacheRepository: CacheRepository,
 ) {
-    companion object {
-        const val BLOOMING_SPOT_KEY = "blooming:spot"
-        const val BLOOMING_EVENT_KEY = "blooming:event"
-        const val BLOOMING_CAFE_KEY = "blooming:cafe"
-        const val BLOOMING_TTL = 30L
-    }
-
     suspend fun add(newBlooming: NewBlooming): Blooming {
         val blooming =
             when (newBlooming) {
@@ -38,9 +27,7 @@ class BloomingService(
             }
         bloomingValidator.addValidate(blooming)
 
-        val result = bloomingAppender.add(newBlooming)
-        evictBloomingCache(newBlooming)
-        return result
+        return bloomingAppender.add(newBlooming)
     }
 
     suspend fun recentlyBloomingBySpotId(spotId: Long): List<Blooming> = bloomingFinder.readRecentlyBloomingBySpotId(spotId)
@@ -49,41 +36,14 @@ class BloomingService(
 
     suspend fun recentlyBloomingByCafeId(cafeId: Long): List<Blooming> = bloomingFinder.readRecentlyBloomingByCafeId(cafeId)
 
-    fun recentlyBloomingBySpotIds(spotIds: List<Long>): List<Blooming> =
-        spotIds.flatMap { spotId -> cachedRecentlyBloomingBySpotId(spotId) }
+    suspend fun recentlyBloomingBySpotIds(spotIds: List<Long>): List<Blooming> =
+        bloomingFinder.recentlyBloomingBySpotIds(spotIds.distinct())
 
-    fun recentlyBloomingByEventIds(eventIds: List<Long>): List<Blooming> =
-        eventIds.flatMap { eventId -> cachedRecentlyBloomingByEventId(eventId) }
+    suspend fun recentlyBloomingByEventIds(eventIds: List<Long>): List<Blooming> =
+        bloomingFinder.recentlyBloomingByEventIds(eventIds.distinct())
 
-    fun recentlyBloomingByCafeIds(cafeIds: List<Long>): List<Blooming> =
-        cafeIds.flatMap { cafeId -> cachedRecentlyBloomingByCafeId(cafeId) }
-
-    private fun cachedRecentlyBloomingBySpotId(spotId: Long): List<Blooming> =
-        Cache.cacheBlocking(
-            ttl = BLOOMING_TTL,
-            key = "$BLOOMING_SPOT_KEY:$spotId",
-            typeReference = object : TypeReference<List<Blooming>>() {},
-        ) {
-            bloomingFinder.recentlyBloomingBySpotIds(listOf(spotId))
-        }
-
-    private fun cachedRecentlyBloomingByEventId(eventId: Long): List<Blooming> =
-        Cache.cacheBlocking(
-            ttl = BLOOMING_TTL,
-            key = "$BLOOMING_EVENT_KEY:$eventId",
-            typeReference = object : TypeReference<List<Blooming>>() {},
-        ) {
-            bloomingFinder.recentlyBloomingByEventIds(listOf(eventId))
-        }
-
-    private fun cachedRecentlyBloomingByCafeId(cafeId: Long): List<Blooming> =
-        Cache.cacheBlocking(
-            ttl = BLOOMING_TTL,
-            key = "$BLOOMING_CAFE_KEY:$cafeId",
-            typeReference = object : TypeReference<List<Blooming>>() {},
-        ) {
-            bloomingFinder.recentlyBloomingByCafeIds(listOf(cafeId))
-        }
+    suspend fun recentlyBloomingByCafeIds(cafeIds: List<Long>): List<Blooming> =
+        bloomingFinder.recentlyBloomingByCafeIds(cafeIds.distinct())
 
     fun verifyTodayBlooming(
         userId: Long,
@@ -103,13 +63,5 @@ class BloomingService(
             }
 
         return bloomingValidator.todayBloomingValidate(blooming)
-    }
-
-    private fun evictBloomingCache(newBlooming: NewBlooming) {
-        when (newBlooming) {
-            is NewBlooming.FlowerSpot -> cacheRepository.delete("$BLOOMING_SPOT_KEY:${newBlooming.flowerSpotId}")
-            is NewBlooming.FlowerEvent -> cacheRepository.delete("$BLOOMING_EVENT_KEY:${newBlooming.flowerEventId}")
-            is NewBlooming.FlowerSpotCafe -> cacheRepository.delete("$BLOOMING_CAFE_KEY:${newBlooming.flowerSpotCafeId}")
-        }
     }
 }

--- a/pida-core/core-domain/src/test/kotlin/com/pida/blooming/BloomingServiceTest.kt
+++ b/pida-core/core-domain/src/test/kotlin/com/pida/blooming/BloomingServiceTest.kt
@@ -1,6 +1,5 @@
 package com.pida.blooming
 
-import com.pida.support.cache.CacheRepository
 import com.pida.support.error.ErrorException
 import com.pida.support.error.ErrorType
 import io.kotest.matchers.shouldBe
@@ -17,8 +16,7 @@ class BloomingServiceTest {
         val bloomingAppender = mockk<BloomingAppender>()
         val bloomingValidator = mockk<BloomingValidator>()
         val bloomingFinder = mockk<BloomingFinder>()
-        val cacheRepository = mockk<CacheRepository>(relaxed = true)
-        val service = BloomingService(bloomingAppender, bloomingValidator, bloomingFinder, cacheRepository)
+        val service = BloomingService(bloomingAppender, bloomingValidator, bloomingFinder)
         val blooming =
             Blooming(
                 id = 1L,
@@ -45,12 +43,92 @@ class BloomingServiceTest {
     }
 
     @Test
+    fun `spot batch 조회는 중복 id를 제거한 뒤 한 번의 finder 호출로 위임한다`() {
+        val bloomingAppender = mockk<BloomingAppender>()
+        val bloomingValidator = mockk<BloomingValidator>()
+        val bloomingFinder = mockk<BloomingFinder>()
+        val service = BloomingService(bloomingAppender, bloomingValidator, bloomingFinder)
+        val bloomings =
+            listOf(
+                Blooming(
+                    id = 1L,
+                    status = BloomingStatus.BLOOMED,
+                    userId = 10L,
+                    flowerSpotId = 30L,
+                    flowerEventId = null,
+                    flowerSpotCafeId = null,
+                    createdAt = LocalDateTime.of(2026, 4, 1, 9, 0),
+                ),
+            )
+
+        every { bloomingFinder.recentlyBloomingBySpotIds(listOf(30L, 31L)) } returns bloomings
+
+        val result = service.recentlyBloomingBySpotIds(listOf(30L, 31L, 30L))
+
+        result shouldBe bloomings
+        verify(exactly = 1) { bloomingFinder.recentlyBloomingBySpotIds(listOf(30L, 31L)) }
+    }
+
+    @Test
+    fun `event batch 조회는 중복 id를 제거한 뒤 한 번의 finder 호출로 위임한다`() {
+        val bloomingAppender = mockk<BloomingAppender>()
+        val bloomingValidator = mockk<BloomingValidator>()
+        val bloomingFinder = mockk<BloomingFinder>()
+        val service = BloomingService(bloomingAppender, bloomingValidator, bloomingFinder)
+        val bloomings =
+            listOf(
+                Blooming(
+                    id = 2L,
+                    status = BloomingStatus.LITTLE,
+                    userId = 11L,
+                    flowerSpotId = null,
+                    flowerEventId = 40L,
+                    flowerSpotCafeId = null,
+                    createdAt = LocalDateTime.of(2026, 4, 1, 10, 0),
+                ),
+            )
+
+        every { bloomingFinder.recentlyBloomingByEventIds(listOf(40L, 41L)) } returns bloomings
+
+        val result = service.recentlyBloomingByEventIds(listOf(40L, 41L, 40L))
+
+        result shouldBe bloomings
+        verify(exactly = 1) { bloomingFinder.recentlyBloomingByEventIds(listOf(40L, 41L)) }
+    }
+
+    @Test
+    fun `cafe batch 조회는 중복 id를 제거한 뒤 한 번의 finder 호출로 위임한다`() {
+        val bloomingAppender = mockk<BloomingAppender>()
+        val bloomingValidator = mockk<BloomingValidator>()
+        val bloomingFinder = mockk<BloomingFinder>()
+        val service = BloomingService(bloomingAppender, bloomingValidator, bloomingFinder)
+        val bloomings =
+            listOf(
+                Blooming(
+                    id = 3L,
+                    status = BloomingStatus.WITHERED,
+                    userId = 12L,
+                    flowerSpotId = null,
+                    flowerEventId = null,
+                    flowerSpotCafeId = 50L,
+                    createdAt = LocalDateTime.of(2026, 4, 1, 11, 0),
+                ),
+            )
+
+        every { bloomingFinder.recentlyBloomingByCafeIds(listOf(50L, 51L)) } returns bloomings
+
+        val result = service.recentlyBloomingByCafeIds(listOf(50L, 51L, 50L))
+
+        result shouldBe bloomings
+        verify(exactly = 1) { bloomingFinder.recentlyBloomingByCafeIds(listOf(50L, 51L)) }
+    }
+
+    @Test
     fun `flowerSpotId와 flowerEventId가 모두 없으면 INVALID_REQUEST를 던진다`() {
         val bloomingAppender = mockk<BloomingAppender>()
         val bloomingValidator = mockk<BloomingValidator>()
         val bloomingFinder = mockk<BloomingFinder>()
-        val cacheRepository = mockk<CacheRepository>(relaxed = true)
-        val service = BloomingService(bloomingAppender, bloomingValidator, bloomingFinder, cacheRepository)
+        val service = BloomingService(bloomingAppender, bloomingValidator, bloomingFinder)
 
         val exception =
             assertThrows<ErrorException> {
@@ -67,8 +145,7 @@ class BloomingServiceTest {
         val bloomingAppender = mockk<BloomingAppender>()
         val bloomingValidator = mockk<BloomingValidator>()
         val bloomingFinder = mockk<BloomingFinder>()
-        val cacheRepository = mockk<CacheRepository>(relaxed = true)
-        val service = BloomingService(bloomingAppender, bloomingValidator, bloomingFinder, cacheRepository)
+        val service = BloomingService(bloomingAppender, bloomingValidator, bloomingFinder)
 
         val exception =
             assertThrows<ErrorException> {

--- a/pida-storage/db-core/src/main/kotlin/com/pida/storage/db/core/blooming/BloomingCoreRepository.kt
+++ b/pida-storage/db-core/src/main/kotlin/com/pida/storage/db/core/blooming/BloomingCoreRepository.kt
@@ -95,18 +95,18 @@ class BloomingCoreRepository(
             bloomingCustomRepository.recentlyByCafeId(cafeId).map { it.toBlooming() }
         }
 
-    override fun findRecentBySpotIds(spotIds: List<Long>): List<Blooming> =
-        Tx.readable {
+    override suspend fun findRecentBySpotIds(spotIds: List<Long>): List<Blooming> =
+        Tx.coReadable {
             bloomingCustomRepository.recentlyBySpotIds(spotIds).map { it.toBlooming() }
         }
 
-    override fun findRecentByEventIds(eventIds: List<Long>): List<Blooming> =
-        Tx.readable {
+    override suspend fun findRecentByEventIds(eventIds: List<Long>): List<Blooming> =
+        Tx.coReadable {
             bloomingCustomRepository.recentlyByEventIds(eventIds).map { it.toBlooming() }
         }
 
-    override fun findRecentByCafeIds(cafeIds: List<Long>): List<Blooming> =
-        Tx.readable {
+    override suspend fun findRecentByCafeIds(cafeIds: List<Long>): List<Blooming> =
+        Tx.coReadable {
             bloomingCustomRepository.recentlyByCafeIds(cafeIds).map { it.toBlooming() }
         }
 


### PR DESCRIPTION
## 🌱 관련 이슈
- close #

## 📌 작업 내용 및 특이 사항

- 개화 상태 캐시 로직 삭제.
- 자주 변경되는 데이터 사항이라 오히려 캐시 연산의 비용이 더 큰 걸로 보아 삭제 

## 📝 참고
```sql
CREATE INDEX CONCURRENTLY idx_blooming_flower_event_id_created_at
ON t_blooming (flower_event_id, created_at);

CREATE INDEX CONCURRENTLY idx_blooming_flower_spot_cafe_id_created_at
ON t_blooming (flower_spot_cafe_id, created_at);
```

추후 개화 상태 테이블에 cafe와 event에 대한 데이터가 급증 시 해당 인덱스 추가할 계획

## 📌 체크 리스트
<!-- 
    조건을 만족하셨다면 공백 대신 x 를 넣어주세요.
    ex:
    - [x] ~~
    - [ ] ~~
-->
- [ ] 리뷰어를 추가하셨나요 ?
- [ ] 변경사항에 대해 충분히 설명하고 있나요 ?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized recently blooming query operations by streamlining internal architecture and improving handling of batch requests with duplicate IDs.

* **Tests**
  * Added test coverage for batch bloom query operations to verify deduplication and correct lookup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->